### PR TITLE
fix: Failure when there is only one $bindable

### DIFF
--- a/packages/extractor/src/extractor/bindings.test.ts
+++ b/packages/extractor/src/extractor/bindings.test.ts
@@ -32,7 +32,7 @@ describe("bindings", () => {
 			</script>
 			<input {id} bind:value />
 		`;
-		const { bindings } = extract(source, create_options("some-bindings.svelte"));
+		const { bindings } = extract(source, create_options("single-bindings.svelte"));
 		expect(bindings).toHaveLength(1);
 		expect(bindings).toContain("value");
 	});
@@ -53,7 +53,7 @@ describe("bindings", () => {
 			</script>
 			<input {id} bind:value bind:borderBoxSize />
 		`;
-		const { bindings } = extract(source, create_options("some-bindings.svelte"));
+		const { bindings } = extract(source, create_options("multiple-bindings.svelte"));
 		expect(bindings).toHaveLength(2);
 		expect(bindings).toContain("value");
 		expect(bindings).toContain("borderBoxSize");

--- a/packages/extractor/src/extractor/bindings.test.ts
+++ b/packages/extractor/src/extractor/bindings.test.ts
@@ -18,7 +18,26 @@ describe("bindings", () => {
 		expect(bindings).toHaveLength(0);
 	});
 
-	it("returns set with names of bindable props", ({ expect }) => {
+	it("returns set with name of a single bindable prop", ({ expect }) => {
+		const source = `
+			<script lang="ts">
+				interface Props {
+					id: string;
+					value?: string;
+				}
+				let {
+					id,
+					value = $bindable(),
+				}: Props = $props();
+			</script>
+			<input {id} bind:value />
+		`;
+		const { bindings } = extract(source, create_options("some-bindings.svelte"));
+		expect(bindings).toHaveLength(1);
+		expect(bindings).toContain("value");
+	});
+
+	it("returns set with names of multiple bindable props", ({ expect }) => {
 		const source = `
 			<script lang="ts">
 				interface Props {

--- a/packages/extractor/src/extractor/mod.js
+++ b/packages/extractor/src/extractor/mod.js
@@ -98,6 +98,9 @@ class Extractor {
 			results.add(bindings.value);
 			return results;
 		}
+		if (bindings.flags & ts.TypeFlags.String) {
+			return results;
+		}
 		// TODO: Document error
 		if (!bindings?.isUnion()) throw new Error("bindings is not an union");
 		for (const type of bindings.types) {

--- a/packages/extractor/src/extractor/mod.js
+++ b/packages/extractor/src/extractor/mod.js
@@ -90,12 +90,12 @@ class Extractor {
 		const { bindings } = this.#extracted_from_render_fn;
 		// TODO: Document error
 		if (!bindings) throw new Error("bindings not found");
-		// NOTE: No bindings, is empty
-		if (
-			//
-			(bindings.isStringLiteral() && bindings.value === "") ||
-			this.checker.typeToString(bindings) === "string"
-		) {
+		if (bindings.isStringLiteral()) {
+			// NOTE: No bindings, is empty
+			if (bindings.value === "") {
+				return results;
+			}
+			results.add(bindings.value);
 			return results;
 		}
 		// TODO: Document error
@@ -320,7 +320,9 @@ class Extractor {
 		//O TODO: Document it
 		if (!from_program)
 			throw new Error(`Source file could not be found by TypeScript program: ${this.compiler.filepath}`);
-		this.#cached_source_file = this.#cache.set(this.compiler.filepath, { source: from_program }).source;
+		this.#cached_source_file = this.#cache.set(this.compiler.filepath, {
+			source: from_program,
+		}).source;
 		return from_program;
 	}
 
@@ -397,20 +399,22 @@ class Extractor {
 		this.#cached_extracted_from_render_fn = {};
 		// biome-ignore format: Prettier
 		for (const prop of properties) {
-			const name = prop.getName();
-			// TODO: Add support for Svelte v4 - exports, slots, and events
-			switch (name) {
-				case "props":
-				case "bindings":
-				case "slots":
-				case "exports":
-				case "events": {
-					this.#cached_extracted_from_render_fn[name] = this.checker.getTypeOfSymbolAtLocation(prop, this.#fn_render);
-					continue;
-				}
-				default: continue;
-			}
-		}
+      const name = prop.getName();
+      // TODO: Add support for Svelte v4 - exports, slots, and events
+      switch (name) {
+        case "props":
+        case "bindings":
+        case "slots":
+        case "exports":
+        case "events": {
+          this.#cached_extracted_from_render_fn[name] =
+            this.checker.getTypeOfSymbolAtLocation(prop, this.#fn_render);
+          continue;
+        }
+        default:
+          continue;
+      }
+    }
 		return this.#cached_extracted_from_render_fn;
 	}
 }

--- a/packages/extractor/src/extractor/mod.js
+++ b/packages/extractor/src/extractor/mod.js
@@ -90,6 +90,11 @@ class Extractor {
 		const { bindings } = this.#extracted_from_render_fn;
 		// TODO: Document error
 		if (!bindings) throw new Error("bindings not found");
+		// If in legacy mode, 'bindings' is a string type
+		if (bindings.flags & ts.TypeFlags.String) {
+			return results;
+		}
+		// If there is a single binding
 		if (bindings.isStringLiteral()) {
 			// NOTE: No bindings, is empty
 			if (bindings.value === "") {
@@ -98,9 +103,7 @@ class Extractor {
 			results.add(bindings.value);
 			return results;
 		}
-		if (bindings.flags & ts.TypeFlags.String) {
-			return results;
-		}
+		// If there are multiple bindings
 		// TODO: Document error
 		if (!bindings?.isUnion()) throw new Error("bindings is not an union");
 		for (const type of bindings.types) {

--- a/packages/extractor/src/extractor/mod.js
+++ b/packages/extractor/src/extractor/mod.js
@@ -399,22 +399,20 @@ class Extractor {
 		this.#cached_extracted_from_render_fn = {};
 		// biome-ignore format: Prettier
 		for (const prop of properties) {
-      const name = prop.getName();
-      // TODO: Add support for Svelte v4 - exports, slots, and events
-      switch (name) {
-        case "props":
-        case "bindings":
-        case "slots":
-        case "exports":
-        case "events": {
-          this.#cached_extracted_from_render_fn[name] =
-            this.checker.getTypeOfSymbolAtLocation(prop, this.#fn_render);
-          continue;
-        }
-        default:
-          continue;
-      }
-    }
+			const name = prop.getName();
+			// TODO: Add support for Svelte v4 - exports, slots, and events
+			switch (name) {
+				case "props":
+				case "bindings":
+				case "slots":
+				case "exports":
+				case "events": {
+					this.#cached_extracted_from_render_fn[name] = this.checker.getTypeOfSymbolAtLocation(prop, this.#fn_render);
+					continue;
+				}
+				default: continue;
+			}
+		}
 		return this.#cached_extracted_from_render_fn;
 	}
 }


### PR DESCRIPTION
This PR fixes an issue that the docgen throws an error for components that have only one `$bindable`.

Example:

```svelte
<script lang="ts">
  interface Props {
    value?: number;
  }
  let { value = $bindable(0) }: Props = $props();
</script>

→ Error "bindings is not a union"
```

