### PR TITLE
Configure .vscode/settings.json and remove Prettier-related settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+	"recommendations": ["biomejs.biome", "svelte.svelte-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,17 @@
+{
+	"[javascript]": {
+		"editor.defaultFormatter": "biomejs.biome",
+		"editor.codeActionsOnSave": { "quickfix.biome": "explicit" }
+	},
+	"[typescript]": {
+		"editor.defaultFormatter": "biomejs.biome",
+		"editor.codeActionsOnSave": { "quickfix.biome": "explicit" }
+	},
+	"[svelte]": {
+		"editor.defaultFormatter": "svelte.svelte-vscode",
+		"editor.formatOnSave": true
+	},
+	"[markdown]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	}
+}

--- a/packages/extractor/src/extractor/mod.js
+++ b/packages/extractor/src/extractor/mod.js
@@ -403,7 +403,6 @@ class Extractor {
 		const return_type = this.checker.getReturnTypeOfSignature(signature);
 		const properties = return_type.getProperties();
 		this.#cached_extracted_from_render_fn = {};
-		// biome-ignore format: Prettier
 		for (const prop of properties) {
 			const name = prop.getName();
 			// TODO: Add support for Svelte v4 - exports, slots, and events
@@ -413,10 +412,14 @@ class Extractor {
 				case "slots":
 				case "exports":
 				case "events": {
-					this.#cached_extracted_from_render_fn[name] = this.checker.getTypeOfSymbolAtLocation(prop, this.#fn_render);
+					this.#cached_extracted_from_render_fn[name] = this.checker.getTypeOfSymbolAtLocation(
+						prop,
+						this.#fn_render,
+					);
 					continue;
 				}
-				default: continue;
+				default:
+					continue;
 			}
 		}
 		return this.#cached_extracted_from_render_fn;

--- a/packages/svelte-docgen/src/parser/mod.js
+++ b/packages/svelte-docgen/src/parser/mod.js
@@ -461,18 +461,27 @@ class Parser {
 	 */
 	#get_type_doc(type) {
 		const kind = get_type_kind({ type, extractor: this.#extractor });
-		// biome-ignore format: Prettier
 		switch (kind) {
-			case "array": return this.#get_array_doc(type);
-			case "constructible": return this.#get_constructible_doc(type);
-			case "function": return this.#get_function_doc(type);
-			case "interface": return this.#get_interface_doc(type);
-			case "intersection": return this.#get_intersection_doc(type);
-			case "literal": return this.#get_literal_doc(type);
-			case "tuple": return this.#get_tuple_doc(type);
-			case "type-parameter": return this.#get_type_param_doc(type);
-			case "union": return this.#get_union_doc(type);
-			default: return { kind };
+			case "array":
+				return this.#get_array_doc(type);
+			case "constructible":
+				return this.#get_constructible_doc(type);
+			case "function":
+				return this.#get_function_doc(type);
+			case "interface":
+				return this.#get_interface_doc(type);
+			case "intersection":
+				return this.#get_intersection_doc(type);
+			case "literal":
+				return this.#get_literal_doc(type);
+			case "tuple":
+				return this.#get_tuple_doc(type);
+			case "type-parameter":
+				return this.#get_type_param_doc(type);
+			case "union":
+				return this.#get_union_doc(type);
+			default:
+				return { kind };
 		}
 	}
 }

--- a/packages/svelte-docgen/src/serde.js
+++ b/packages/svelte-docgen/src/serde.js
@@ -40,15 +40,17 @@ export function serialize(data, indent) {
  */
 export function deserialize(stringified) {
 	return JSON.parse(stringified, (key, value) => {
-		// biome-ignore format: Prettier
 		switch (key) {
 			case "exports":
 			case "events":
 			case "members":
 			case "props":
-			case "slots": return is_mapable(value) ? new Map(value) : value;
-			case "sources": return is_setable(value) ? new Set(value) : value;
-			default: return value;
+			case "slots":
+				return is_mapable(value) ? new Map(value) : value;
+			case "sources":
+				return is_setable(value) ? new Set(value) : value;
+			default:
+				return value;
 		}
 	});
 }


### PR DESCRIPTION
Rationales:

- The Prettier extension and Biome conflict in my VS Code environment, causing unpredictable formatting changes.
    - Adding `.vscode/settings.json` enforces Biome as the default formatter.
- If we adopt Biome, the Prettier extension becomes redundant for .js/.ts files.
- The official Svelte repository also uses `.vscode/` (e.g., [svelte/svelte](https://github.com/sveltejs/svelte/tree/main/.vscode), [svelte/cli](https://github.com/sveltejs/cli/tree/main/.vscode)).