### PR TITLE
ci: Use ubuntu runner (?)

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
     biome:
         name: Biome
-        runs-on: macos-latest
+        runs-on: ubuntu-latest
         timeout-minutes: 1
         steps:
             # https://github.com/actions/checkout

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -13,7 +13,7 @@ env:
 jobs:
     preview-release:
         name: pkg.pr.new
-        runs-on: macos-latest
+        runs-on: ubuntu-latest
         timeout-minutes: 5
         steps:
             # https://github.com/actions/checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
     changesets:
         name: Release
-        runs-on: macos-latest
+        runs-on: ubuntu-latest
         timeout-minutes: 1
         steps:
             # https://github.com/actions/checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
     vitest:
         name: Vitest
-        runs-on: macos-latest
+        runs-on: ubuntu-latest
         timeout-minutes: 2
         steps:
             # https://github.com/actions/checkout

--- a/.github/workflows/tsc.yml
+++ b/.github/workflows/tsc.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
     tsc:
         name: tsc
-        runs-on: macos-latest
+        runs-on: ubuntu-latest
         timeout-minutes: 2
         steps:
             # https://github.com/actions/checkout

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -30,7 +30,7 @@ permissions:
 jobs:
     typedoc:
         name: TypeDoc
-        runs-on: macos-latest
+        runs-on: ubuntu-latest
         timeout-minutes: 2
         steps:
             # https://github.com/actions/checkout

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
     typos:
         name: Typos
-        runs-on: macos-latest
+        runs-on: ubuntu-latest
         steps:
             # https://github.com/actions/checkout
             - name: Checkout to the repository


### PR DESCRIPTION
Wouldn’t the standard Ubuntu runner offer better performance than the macOS runner?

---

**Update**: Surprisingly, switching to the Ubuntu runner resulted in slightly longer CI times.