### PR TITLE
chore: API naming improvements

### DIFF
--- a/packages/svelte-docgen/src/analyzer/component.js
+++ b/packages/svelte-docgen/src/analyzer/component.js
@@ -1,13 +1,13 @@
 /**
  * @import { Doc } from "../doc/type.ts";
- * @import { ParsedComponent } from "../parser/mod.ts";
+ * @import { ComponentDocgen } from "../parser/mod.ts";
  */
 
 class ComponentAnalyzer {
-	/** @type {ParsedComponent} */
+	/** @type {ComponentDocgen} */
 	#component;
 
-	/** @param {ParsedComponent} component */
+	/** @param {ComponentDocgen} component */
 	constructor(component) {
 		this.#component = component;
 	}
@@ -40,7 +40,7 @@ class ComponentAnalyzer {
 }
 
 /**
- * @param {ParsedComponent} component
+ * @param {ComponentDocgen} component
  * @returns {ComponentAnalyzer}
  */
 export function analyzeComponent(component) {

--- a/packages/svelte-docgen/src/codec.js
+++ b/packages/svelte-docgen/src/codec.js
@@ -17,7 +17,7 @@ import * as v from "valibot";
  * @param {Parameters<typeof JSON.stringify>[2]} [indent]
  * @returns {string}
  */
-export function serialize(data, indent) {
+export function encode(data, indent) {
 	return JSON.stringify(
 		data,
 		(key, value) => {
@@ -38,7 +38,7 @@ export function serialize(data, indent) {
  * @param {string} stringified
  * @returns {Partial<ComponentDocgen>}
  */
-export function deserialize(stringified) {
+export function decode(stringified) {
 	return JSON.parse(stringified, (key, value) => {
 		// biome-ignore format: Prettier
 		switch (key) {

--- a/packages/svelte-docgen/src/codec.test.ts
+++ b/packages/svelte-docgen/src/codec.test.ts
@@ -2,9 +2,9 @@ import { describe, it } from "vitest";
 
 import { create_options } from "../tests/shared.js";
 import { parse } from "./parser/mod.js";
-import { deserialize, serialize } from "./serde.js";
+import { decode, encode } from "./codec.js";
 
-describe("serialize", () => {
+describe("encode", () => {
 	const parsed = parse(
 		`
 			<script lang="ts">
@@ -19,9 +19,9 @@ describe("serialize", () => {
 			`,
 		create_options("serialize.svelte"),
 	);
-	const serialized = serialize(parsed, 2);
+	const encoded = encode(parsed, 2);
 	it("converts 'props' to array of tuples", ({ expect }) => {
-		expect(serialized).toMatchInlineSnapshot(
+		expect(encoded).toMatchInlineSnapshot(
 			`
 			{
 			  "exports": [],
@@ -259,7 +259,7 @@ describe("serialize", () => {
 	});
 });
 
-describe("deserialize", () => {
+describe("decode", () => {
 	it("revives 'props' as Map", ({ expect }) => {
 		const parsed = parse(
 			`
@@ -275,9 +275,9 @@ describe("deserialize", () => {
 			`,
 			create_options("deserialize.svelte"),
 		);
-		const serialized = serialize(parsed);
-		const deserialized = deserialize(serialized);
-		expect(deserialized.props).toBeInstanceOf(Map);
+		const encoded = encode(parsed);
+		const decoded = decode(encoded);
+		expect(decoded.props).toBeInstanceOf(Map);
 		//
 	});
 });

--- a/packages/svelte-docgen/src/parser/mod.js
+++ b/packages/svelte-docgen/src/parser/mod.js
@@ -39,7 +39,7 @@ class Parser {
 		this.#extractor = extract(source, this.#options);
 	}
 
-	/** @returns {ParsedComponent} */
+	/** @returns {ComponentDocgen} */
 	toJSON() {
 		const { description, isLegacy, exports, props, tags } = this;
 		if (isLegacy) {
@@ -499,12 +499,12 @@ class Parser {
  * @prop {never} slots
  */
 
-/** @typedef {LegacyComponent | ModernComponent} ParsedComponent */
+/** @typedef {LegacyComponent | ModernComponent} ComponentDocgen */
 
 /**
  * @param {string} source
  * @param {UserOptions} user_options
- * @returns {ParsedComponent}
+ * @returns {ComponentDocgen}
  */
 export function parse(source, user_options = {}) {
 	// @ts-expect-error WARN: Didn't want to use type casting here

--- a/packages/svelte-docgen/src/serde.js
+++ b/packages/svelte-docgen/src/serde.js
@@ -5,7 +5,7 @@
  */
 
 /**
- * @import { ParsedComponent } from "./parser/mod.js";
+ * @import { ComponentDocgen } from "./parser/mod.js";
  */
 
 import * as v from "valibot";
@@ -13,7 +13,7 @@ import * as v from "valibot";
 /**
  * Serialize data as stringified JSON, so it can be used for e.g. RESTful API.
  *
- * @param {ParsedComponent} data
+ * @param {ComponentDocgen} data
  * @param {Parameters<typeof JSON.stringify>[2]} [indent]
  * @returns {string}
  */
@@ -36,7 +36,7 @@ export function serialize(data, indent) {
  * Revive stringified JSON data back to previous interface.
  *
  * @param {string} stringified
- * @returns {Partial<ParsedComponent>}
+ * @returns {Partial<ComponentDocgen>}
  */
 export function deserialize(stringified) {
 	return JSON.parse(stringified, (key, value) => {


### PR DESCRIPTION
- **`ParsedComponent` -> `ComponentDocgen`**

From user perspective, I believe it is easier to understand.

- **`serde` -> `codec`
- `serialize` -> `encode`
- `deserialize` -> `decode`**

This was caused by this [BlueSky post](https://bsky.app/profile/reinhold.is/post/3ld4yil25vk2f)

I also believe it makes sense. Because we're not actually serializing into bytes _(like in Rust)_.
We just change format to what JSON can understand.
