### PR TITLE
fix: Improve .svelte file resolution in the Vite plugin

### DIFF
--- a/packages/vite-plugin-svelte-docgen/scripts/post-build.ts
+++ b/packages/vite-plugin-svelte-docgen/scripts/post-build.ts
@@ -8,7 +8,7 @@ const __dirname = path.dirname(__filename);
 function main(): void {
 	const types_filepath = url.pathToFileURL(path.join(__dirname, "..", "types", "mod.d.ts"));
 	const content = `
-declare module "virtual:*.docgen.js" {
+declare module "*.svelte?docgen" {
 	import type { parse } from "svelte-docgen";
 	const content: ReturnType<typeof parse>;
 	export default content;

--- a/packages/vite-plugin-svelte-docgen/src/mod.js
+++ b/packages/vite-plugin-svelte-docgen/src/mod.js
@@ -6,7 +6,6 @@
  */
 
 import fs from "node:fs";
-import path from "node:path";
 import url from "node:url";
 
 import { print } from "esrap";
@@ -23,21 +22,17 @@ const CACHE_STORAGE = docgen.createCacheStorage();
  */
 async function plugin(user_options) {
 	// TODO: Decide whether there is a need for plugin options
-	const options = new Options(user_options);
+	// const user_options = new Options(user_options);
 	return {
 		name: "vite-plugin-svelte-docgen",
 		enforce: "pre",
-		resolveId(id, importer) {
+		async resolveId(source, importer, options) {
+			// https://rollupjs.org/plugin-development/#resolveid
 			if (!importer) return;
-			if (!id.endsWith(".svelte?docgen")) return;
-			const svelte_filepath = url.pathToFileURL(
-				path.join(
-					//
-					path.dirname(importer),
-					id.replace("?docgen", ""),
-				),
-			);
-			if (fs.existsSync(svelte_filepath)) {
+			if (!source.endsWith(".svelte?docgen")) return;
+			const resolution = await this.resolve(source.replace(/\?docgen$/, ""), importer, options);
+			if (resolution) {
+				const svelte_filepath = url.pathToFileURL(resolution.id);
 				return `\0virtual:${svelte_filepath.pathname}.docgen.js`;
 			}
 		},

--- a/packages/vite-plugin-svelte-docgen/src/mod.test.ts
+++ b/packages/vite-plugin-svelte-docgen/src/mod.test.ts
@@ -27,6 +27,18 @@ describe("plugin", async () => {
 		expect(docgen.default.props).toBeInstanceOf(Map);
 		expect(docgen.default.props.size).toBe(443);
 	});
+
+	it("should handle both relative paths to importer and absolute paths from the project root", async ({ expect }) => {
+		const expected = `\x00virtual:${path.resolve(__dirname, "../examples/button.svelte")}.docgen.js`
+		// relative
+		expect(
+			(await VITE_DEV_SERVER.pluginContainer.resolveId("../examples/button.svelte?docgen", __filename))?.id
+		).toBe(expected)
+		// absolute
+		expect(
+			(await VITE_DEV_SERVER.pluginContainer.resolveId("/examples/button.svelte?docgen", __filename))?.id
+		).toBe(expected);
+	})
 });
 
 afterEach(async () => {

--- a/packages/vite-plugin-svelte-docgen/src/mod.test.ts
+++ b/packages/vite-plugin-svelte-docgen/src/mod.test.ts
@@ -29,16 +29,16 @@ describe("plugin", async () => {
 	});
 
 	it("should handle both relative paths to importer and absolute paths from the project root", async ({ expect }) => {
-		const expected = `\x00virtual:${path.resolve(__dirname, "../examples/button.svelte")}.docgen.js`
+		const expected = `\x00virtual:${path.resolve(__dirname, "../examples/button.svelte")}.docgen.js`;
 		// relative
 		expect(
-			(await VITE_DEV_SERVER.pluginContainer.resolveId("../examples/button.svelte?docgen", __filename))?.id
-		).toBe(expected)
+			(await VITE_DEV_SERVER.pluginContainer.resolveId("../examples/button.svelte?docgen", __filename))?.id,
+		).toBe(expected);
 		// absolute
 		expect(
-			(await VITE_DEV_SERVER.pluginContainer.resolveId("/examples/button.svelte?docgen", __filename))?.id
+			(await VITE_DEV_SERVER.pluginContainer.resolveId("/examples/button.svelte?docgen", __filename))?.id,
 		).toBe(expected);
-	})
+	});
 });
 
 afterEach(async () => {


### PR DESCRIPTION
This PR makes the .svelte file resolution more robust.

While testing with a SvelteKit project, I discovered the current implementation of the Vite plugin doesn’t work when generating the client-side code. The issue arises from an inconsistency in the paths provided to the `resolveId` method:

- For server-side code generation, both `source` and `importer` are absolute paths:
     `source = "/User/path/to/repo/src/lib/components/Component.svelte"`

- For client-side code generation, `source` becomes an _absolute_ path starting from the project root:
      `source = "/src/lib/components/Component.svelte"`