### PR TITLE
test: Improve snapshots serializer - `<semver>`

### DIFF
--- a/packages/svelte-docgen/src/parser/events.test.ts
+++ b/packages/svelte-docgen/src/parser/events.test.ts
@@ -68,7 +68,7 @@ describe("events", () => {
 			                      "alias": "NonNullable",
 			                      "kind": "intersection",
 			                      "sources": Set {
-			                        <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.es5.d.ts,
+			                        <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es5.d.ts,
 			                      },
 			                      "types": [
 			                        {
@@ -176,7 +176,7 @@ describe("events", () => {
 			                },
 			              },
 			              "sources": Set {
-			                <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.dom.d.ts,
+			                <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.dom.d.ts,
 			              },
 			            },
 			            "types": [
@@ -196,7 +196,7 @@ describe("events", () => {
 			                        "alias": "NonNullable",
 			                        "kind": "intersection",
 			                        "sources": Set {
-			                          <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.es5.d.ts,
+			                          <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es5.d.ts,
 			                        },
 			                        "types": [
 			                          {
@@ -304,7 +304,7 @@ describe("events", () => {
 			                  },
 			                },
 			                "sources": Set {
-			                  <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.dom.d.ts,
+			                  <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.dom.d.ts,
 			                },
 			              },
 			            ],
@@ -315,7 +315,7 @@ describe("events", () => {
 			    "kind": "constructible",
 			    "name": "CustomEvent",
 			    "sources": Set {
-			      <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.dom.d.ts,
+			      <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.dom.d.ts,
 			    },
 			  },
 			  "on:increment" => {
@@ -323,7 +323,7 @@ describe("events", () => {
 			    "kind": "constructible",
 			    "name": "CustomEvent",
 			    "sources": Set {
-			      <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.dom.d.ts,
+			      <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.dom.d.ts,
 			    },
 			  },
 			}

--- a/packages/svelte-docgen/src/parser/props.test.ts
+++ b/packages/svelte-docgen/src/parser/props.test.ts
@@ -280,7 +280,7 @@ describe("props", () => {
 			  "isExtended": true,
 			  "isOptional": true,
 			  "sources": Set {
-			    <process-cwd>/node_modules/.pnpm/svelte@5.3.1/node_modules/svelte/elements.d.ts,
+			    <process-cwd>/node_modules/.pnpm/svelte@<semver>/node_modules/svelte/elements.d.ts,
 			  },
 			  "tags": [],
 			  "type": {
@@ -312,7 +312,7 @@ describe("props", () => {
 		expect(disabled?.isExtended).toBe(true);
 		expect(disabled?.sources).toMatchInlineSnapshot(`
 			Set {
-			  <process-cwd>/node_modules/.pnpm/svelte@5.3.1/node_modules/svelte/elements.d.ts,
+			  <process-cwd>/node_modules/.pnpm/svelte@<semver>/node_modules/svelte/elements.d.ts,
 			}
 		`);
 		if (disabled?.isExtended && disabled?.sources) {

--- a/packages/svelte-docgen/src/parser/type/constructible.test.ts
+++ b/packages/svelte-docgen/src/parser/type/constructible.test.ts
@@ -230,9 +230,9 @@ describe("Constructible", () => {
 			              "kind": "constructible",
 			              "name": "Date",
 			              "sources": Set {
-			                <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.es5.d.ts,
-			                <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts,
-			                <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.es2020.date.d.ts,
+			                <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es5.d.ts,
+			                <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts,
+			                <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2020.date.d.ts,
 			              },
 			            },
 			          ],
@@ -243,9 +243,9 @@ describe("Constructible", () => {
 			  "kind": "constructible",
 			  "name": "Date",
 			  "sources": Set {
-			    <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.es5.d.ts,
-			    <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts,
-			    <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.es2020.date.d.ts,
+			    <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es5.d.ts,
+			    <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts,
+			    <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2020.date.d.ts,
 			  },
 			}
 		`);
@@ -355,8 +355,8 @@ describe("Constructible", () => {
 			                        "kind": "constructible",
 			                        "name": "Iterator",
 			                        "sources": Set {
-			                          <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.es2015.iterable.d.ts,
-			                          <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.esnext.iterator.d.ts,
+			                          <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.iterable.d.ts,
+			                          <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.esnext.iterator.d.ts,
 			                        },
 			                      },
 			                    },
@@ -366,7 +366,7 @@ describe("Constructible", () => {
 			              },
 			            },
 			            "sources": Set {
-			              <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.es2015.iterable.d.ts,
+			              <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.iterable.d.ts,
 			            },
 			          },
 			          "types": [
@@ -395,8 +395,8 @@ describe("Constructible", () => {
 			                          "kind": "constructible",
 			                          "name": "Iterator",
 			                          "sources": Set {
-			                            <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.es2015.iterable.d.ts,
-			                            <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.esnext.iterator.d.ts,
+			                            <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.iterable.d.ts,
+			                            <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.esnext.iterator.d.ts,
 			                          },
 			                        },
 			                      },
@@ -406,7 +406,7 @@ describe("Constructible", () => {
 			                },
 			              },
 			              "sources": Set {
-			                <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.es2015.iterable.d.ts,
+			                <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.iterable.d.ts,
 			              },
 			            },
 			          ],
@@ -417,9 +417,9 @@ describe("Constructible", () => {
 			  "kind": "constructible",
 			  "name": "Map",
 			  "sources": Set {
-			    <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.es2015.collection.d.ts,
-			    <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.es2015.iterable.d.ts,
-			    <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts,
+			    <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.collection.d.ts,
+			    <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.iterable.d.ts,
+			    <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts,
 			  },
 			}
 		`);
@@ -505,8 +505,8 @@ describe("Constructible", () => {
 			                        "kind": "constructible",
 			                        "name": "Iterator",
 			                        "sources": Set {
-			                          <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.es2015.iterable.d.ts,
-			                          <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.esnext.iterator.d.ts,
+			                          <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.iterable.d.ts,
+			                          <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.esnext.iterator.d.ts,
 			                        },
 			                      },
 			                    },
@@ -516,7 +516,7 @@ describe("Constructible", () => {
 			              },
 			            },
 			            "sources": Set {
-			              <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.es2015.iterable.d.ts,
+			              <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.iterable.d.ts,
 			            },
 			          },
 			          "types": [
@@ -545,8 +545,8 @@ describe("Constructible", () => {
 			                          "kind": "constructible",
 			                          "name": "Iterator",
 			                          "sources": Set {
-			                            <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.es2015.iterable.d.ts,
-			                            <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.esnext.iterator.d.ts,
+			                            <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.iterable.d.ts,
+			                            <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.esnext.iterator.d.ts,
 			                          },
 			                        },
 			                      },
@@ -556,7 +556,7 @@ describe("Constructible", () => {
 			                },
 			              },
 			              "sources": Set {
-			                <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.es2015.iterable.d.ts,
+			                <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.iterable.d.ts,
 			              },
 			            },
 			          ],
@@ -567,10 +567,10 @@ describe("Constructible", () => {
 			  "kind": "constructible",
 			  "name": "Set",
 			  "sources": Set {
-			    <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.es2015.collection.d.ts,
-			    <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.es2015.iterable.d.ts,
-			    <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts,
-			    <process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.esnext.collection.d.ts,
+			    <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.collection.d.ts,
+			    <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.iterable.d.ts,
+			    <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts,
+			    <process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.esnext.collection.d.ts,
 			  },
 			}
 		`);

--- a/packages/svelte-docgen/src/serde.test.ts
+++ b/packages/svelte-docgen/src/serde.test.ts
@@ -234,7 +234,7 @@ describe("serialize", () => {
 			                      "name": "Date",
 			                      "constructors": "self",
 			                      "sources": [
-			                        "<process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.es5.d.ts",
+			                        "<process-cwd>/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es5.d.ts",
 			                        "<process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
 			                        "<process-cwd>/node_modules/.pnpm/typescript@5.7.2/node_modules/typescript/lib/lib.es2020.date.d.ts"
 			                      ]

--- a/tests/snapshot-serializer.ts
+++ b/tests/snapshot-serializer.ts
@@ -7,8 +7,18 @@ const __dirname = path.dirname(__filename);
 import type { SnapshotSerializer } from "vitest";
 
 const ROOT_PATH = path.join(__dirname, "..");
+const REGEX_PACKAGE_VERSION = /(?<package>[\w-]+)@(?<semver>\d+\.\d+\.\d+)/;
 
 export default {
-	test: (value) => typeof value === "string" && value.includes(ROOT_PATH),
-	print: (value) => (typeof value === "string" ? value.replace(new RegExp(ROOT_PATH, "g"), "<process-cwd>") : ""),
+	test: (value) => {
+		return typeof value === "string" && (value.includes(ROOT_PATH) || REGEX_PACKAGE_VERSION.test(value));
+	},
+	print: (value) => {
+		if (typeof value === "string") {
+			return value
+				.replace(new RegExp(ROOT_PATH, "g"), "<process-cwd>")
+				.replace(REGEX_PACKAGE_VERSION, "$<package>@<semver>");
+		}
+		return "";
+	},
 } satisfies SnapshotSerializer;

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -2,33 +2,33 @@ import path from "node:path";
 import url from "node:url";
 
 import { loadEnv } from "vite";
-import { defineWorkspace } from "vitest/config";
+import { type UserWorkspaceConfig, defineWorkspace } from "vitest/config";
 
 const __filename = url.fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+const SHARED = {
+	env: Object.assign(process.env, loadEnv("", path.resolve(__dirname), "")),
+	snapshotSerializers: [path.resolve(__dirname, "tests", "snapshot-serializer.ts")],
+	typecheck: {
+		enabled: true,
+	},
+} satisfies NonNullable<UserWorkspaceConfig>["test"];
 
 /** @see {@link https://vitest.dev/guide/workspace} */
 const config = defineWorkspace([
 	{
 		test: {
+			...SHARED,
 			name: "@svelte-docgen/extractor",
 			root: path.resolve(__dirname, "packages", "extractor"),
-			env: Object.assign(process.env, loadEnv("", path.resolve(__dirname), "")),
-			snapshotSerializers: [path.resolve(__dirname, "tests", "snapshot-serializer.ts")],
-			typecheck: {
-				enabled: true,
-			},
 		},
 	},
 	{
 		test: {
+			...SHARED,
 			name: "svelte-docgen",
 			root: path.resolve(__dirname, "packages", "svelte-docgen"),
-			env: Object.assign(process.env, loadEnv("", path.resolve(__dirname), "")),
-			snapshotSerializers: [path.resolve(__dirname, "tests", "snapshot-serializer.ts")],
-			typecheck: {
-				enabled: true,
-			},
 		},
 	},
 ]);


### PR DESCRIPTION
In PR #19 I noticed that we'll be bothered to update snapshots everytime we update dependencies.

See the comment with example: <https://github.com/svelte-docgen/svelte-docgen/pull/19#discussion_r1885550919>

So, this gives extra ability to the current snapshots serializer to wrap any semver pattern with `<semver>`.
Information about version of either `svelte`, `typescript` or anything else is more important on the user side.
