### PR TITLE
chore(vite-plugin): Move `svelte-docgen` to `peerDependencies`

### DIFF
--- a/packages/vite-plugin-svelte-docgen/package.json
+++ b/packages/vite-plugin-svelte-docgen/package.json
@@ -86,7 +86,6 @@
 	},
 	"dependencies": {
 		"esrap": "^1.2.3",
-		"svelte-docgen": "workspace:*",
 		"zimmerframe": "^1.1.2"
 	},
 	"devDependencies": {
@@ -95,6 +94,7 @@
 	},
 	"peerDependencies": {
 		"svelte": "catalog:",
+		"svelte-docgen": "workspace:*",
 		"typescript": "catalog:",
 		"vite": "catalog:"
 	}


### PR DESCRIPTION
I noticed this when creating a draft PR for Storybook.

I believe that's the right way, based on examples like `@sveltejs/vite-plugin-svelte` and it's [`package.json`](https://github.com/sveltejs/vite-plugin-svelte/blob/35de4ee3e8dd25567e45d60f0844b10e0afb5ee8/packages/vite-plugin-svelte/package.json#L51-L54)
