### PR TITLE
feat: Initial support for non-Node runtimes with experimental 'playground'

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,39 +1,29 @@
 {
-  "projectName": "svelte-docgen",
-  "projectOwner": "svelte-docgen",
-  "repoType": "github",
-  "repoHost": "https://github.com",
-  "files": [
-    "README.md"
-  ],
-  "imageSize": 50,
-  "commit": true,
-  "commitConvention": "angular",
-  "contributors": [
-    {
-      "login": "xeho91",
-      "name": "Mateusz Kadlubowski",
-      "avatar_url": "https://avatars.githubusercontent.com/u/18627568?v=4",
-      "profile": "https://github.com/xeho91",
-      "contributions": [
-        "code",
-        "infra",
-        "maintenance"
-      ]
-    },
-    {
-      "login": "ciscorn",
-      "name": "Taku Fukada",
-      "avatar_url": "https://avatars.githubusercontent.com/u/5351911?v=4",
-      "profile": "https://github.com/ciscorn",
-      "contributions": [
-        "code",
-        "infra",
-        "maintenance"
-      ]
-    }
-  ],
-  "contributorsPerLine": 7,
-  "linkToUsage": false,
-  "commitType": "docs"
+	"projectName": "svelte-docgen",
+	"projectOwner": "svelte-docgen",
+	"repoType": "github",
+	"repoHost": "https://github.com",
+	"files": ["README.md"],
+	"imageSize": 50,
+	"commit": true,
+	"commitConvention": "angular",
+	"contributors": [
+		{
+			"login": "xeho91",
+			"name": "Mateusz Kadlubowski",
+			"avatar_url": "https://avatars.githubusercontent.com/u/18627568?v=4",
+			"profile": "https://github.com/xeho91",
+			"contributions": ["code", "infra", "maintenance"]
+		},
+		{
+			"login": "ciscorn",
+			"name": "Taku Fukada",
+			"avatar_url": "https://avatars.githubusercontent.com/u/5351911?v=4",
+			"profile": "https://github.com/ciscorn",
+			"contributions": ["code", "infra", "maintenance"]
+		}
+	],
+	"contributorsPerLine": 7,
+	"linkToUsage": false,
+	"commitType": "docs"
 }

--- a/.changeset/nine-starfishes-drop.md
+++ b/.changeset/nine-starfishes-drop.md
@@ -1,0 +1,7 @@
+---
+"svelte-docgen": patch
+"@svelte-docgen/extractor": patch
+"docs": patch
+---
+
+Initial support for non-Node runtimes with experimental 'playground'

--- a/.changeset/pink-pens-tickle.md
+++ b/.changeset/pink-pens-tickle.md
@@ -1,0 +1,5 @@
+---
+"@svelte-docgen/extractor": patch
+---
+
+Fixed a cache key bug and resolved an issue caused by root_names reuse

--- a/apps/docs/.prettierignore
+++ b/apps/docs/.prettierignore
@@ -2,3 +2,6 @@
 package-lock.json
 pnpm-lock.yaml
 yarn.lock
+
+.svelte-kit
+.sveltepress

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -16,7 +16,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-cloudflare": "^4.9.0",
-		"@sveltejs/kit": "^2.13.0",
+		"@sveltejs/kit": "^2.14.0",
 		"@sveltejs/vite-plugin-svelte": "^5.0.3",
 		"@sveltepress/theme-default": "^5.0.5",
 		"@sveltepress/vite": "^1.1.2",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -22,7 +22,7 @@
 		"@sveltepress/vite": "^1.1.2",
 		"@typescript/vfs": "^1.6.0",
 		"autoprefixer": "^10.4.20",
-		"runed": "^0.21.0",
+		"runed": "^0.22.0",
 		"svelte": "catalog:",
 		"svelte-docgen": "workspace:*",
 		"svelte2tsx": "^0.7.31"

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -15,12 +15,16 @@
 		"test": "npm run test:unit -- --run"
 	},
 	"devDependencies": {
-		"@sveltejs/adapter-cloudflare": "^4.8.0",
-		"@sveltejs/kit": "^2.12.1",
-		"@sveltejs/vite-plugin-svelte": "^5.0.2",
+		"@sveltejs/adapter-cloudflare": "^4.9.0",
+		"@sveltejs/kit": "^2.13.0",
+		"@sveltejs/vite-plugin-svelte": "^5.0.3",
 		"@sveltepress/theme-default": "^5.0.5",
 		"@sveltepress/vite": "^1.1.2",
+		"@typescript/vfs": "^1.6.0",
 		"autoprefixer": "^10.4.20",
-		"svelte": "catalog:"
+		"runed": "^0.21.0",
+		"svelte": "catalog:",
+		"svelte-docgen": "workspace:*",
+		"svelte2tsx": "^0.7.31"
 	}
 }

--- a/apps/docs/src/routes/demo-playground/+page.svelte
+++ b/apps/docs/src/routes/demo-playground/+page.svelte
@@ -19,6 +19,7 @@
 			const fsmap = await tsvfs.createDefaultMapFromCDN(
 				{
 					lib: ["ESNext", "DOM", "DOM.Iterable"],
+					moduleResolution: ts.ModuleResolutionKind.Bundler,
 					target: ts.ScriptTarget.ESNext,
 				},
 				ts.version,
@@ -45,6 +46,7 @@
 			error = "";
 		} catch (e) {
 			error = String(e);
+			throw e;
 		}
 	});
 </script>

--- a/apps/docs/src/routes/demo-playground/+page.svelte
+++ b/apps/docs/src/routes/demo-playground/+page.svelte
@@ -18,7 +18,7 @@
 		(async () => {
 			const fsmap = await tsvfs.createDefaultMapFromCDN(
 				{
-					lib: ["esnext", "DOM", "DOM.Iterable"],
+					lib: ["ESNext", "DOM", "DOM.Iterable"],
 					target: ts.ScriptTarget.ESNext,
 				},
 				ts.version,

--- a/apps/docs/src/routes/demo-playground/+page.svelte
+++ b/apps/docs/src/routes/demo-playground/+page.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+	import ts from "typescript";
+	import * as tsvfs from "@typescript/vfs";
+
+	import { browser } from "$app/environment";
+	import { Debounced } from "runed";
+
+	import { prepareDocgen } from "./demo";
+	import initial from "./initial.txt?raw";
+
+	let docgen: ((source: string) => string) | undefined = $state();
+	let source = $state(initial);
+	let debouncedSource = new Debounced(() => source, 500);
+	let encoded = $state("");
+	let error: string = $state("");
+
+	if (browser) {
+		(async () => {
+			const fsmap = await tsvfs.createDefaultMapFromCDN(
+				{
+					lib: ["esnext", "DOM", "DOM.Iterable"],
+					target: ts.ScriptTarget.ESNext,
+				},
+				ts.version,
+				true,
+				ts,
+				// lzstring
+			);
+
+			for (const [k, v] of Object.entries(
+				import.meta.glob("/node_modules/svelte/**/*.d.ts", { query: "?raw", exhaustive: true, eager: true }),
+			)) {
+				// @ts-expect-error: v is a string
+				fsmap.set(k, v.default);
+			}
+
+			docgen = prepareDocgen(fsmap);
+		})();
+	}
+
+	$effect(() => {
+		if (!docgen) return;
+		try {
+			encoded = docgen(debouncedSource.current);
+			error = "";
+		} catch (e) {
+			error = String(e);
+		}
+	});
+</script>
+
+<textarea bind:value={source} rows="10" style="width: 100%;"></textarea>
+
+{#if error}
+	<pre style="color: red;">{error}</pre>
+{/if}
+
+{#if docgen}
+	<pre>{encoded}</pre>
+{:else}
+	loading docgen...
+{/if}

--- a/apps/docs/src/routes/demo-playground/demo.ts
+++ b/apps/docs/src/routes/demo-playground/demo.ts
@@ -6,7 +6,7 @@ import { parse, createCacheStorage, encode } from "svelte-docgen";
 import shim from "svelte2tsx/svelte-shims-v4.d.ts?raw";
 
 export function prepareDocgen(fsmap: Map<string, string>) {
-	fsmap.set("/svelte2tsx/svelte-shims-v4.d.ts", shim);
+	fsmap.set("/node_modules/svelte2tsx/svelte-shims-v4.d.ts", shim);
 
 	const system = tsvfs.createSystem(fsmap);
 	const cache = createCacheStorage(system);

--- a/apps/docs/src/routes/demo-playground/demo.ts
+++ b/apps/docs/src/routes/demo-playground/demo.ts
@@ -11,35 +11,6 @@ export function prepareDocgen(fsmap: Map<string, string>) {
 	const system = tsvfs.createSystem(fsmap);
 	const cache = createCacheStorage(system);
 
-	// const debug_system: ts.System = {
-	//   ...system,
-	//   fileExists(p){
-	// 		const r = system.fileExists(p);
-	// 		console.log("fileexists", p, "=>", r);
-	// 		return r;
-	// 	},
-	// 	readFile (p) {
-	// 		const r = system.readFile(p);
-	// 		console.log("readfile", p, "=>", r ? "found" : "not found");
-	// 		return r;
-	// 	},
-	// 	readDirectory (path, extensions, exclude, include, depth) {
-	// 		const r = system.readDirectory(path, extensions, exclude, include, depth);
-	// 		console.log("readDirectory", path, "=>", r);
-	// 		return r;
-	// 	},
-	// 	getCurrentDirectory() {
-	// 		const r = system.getCurrentDirectory();
-	// 		console.log("getCurrentDirectory", "=>", r);
-	// 		return r;
-	// 	},
-	// 	directoryExists(p) {
-	// 		const r = system.directoryExists(p);
-	// 		console.log("directoryExists", p, "=>", r);
-	// 		return r;
-	// 	},
-	// }
-
 	return (source: string) => {
 		cache.delete("/src/Demo.svelte.tsx");
 		const parsed = parse(source, {

--- a/apps/docs/src/routes/demo-playground/demo.ts
+++ b/apps/docs/src/routes/demo-playground/demo.ts
@@ -1,0 +1,53 @@
+import ts from "typescript";
+import * as tsvfs from "@typescript/vfs";
+
+import { parse, createCacheStorage, encode } from "svelte-docgen";
+
+import shim from "svelte2tsx/svelte-shims-v4.d.ts?raw";
+
+export function prepareDocgen(fsmap: Map<string, string>) {
+	fsmap.set("/svelte2tsx/svelte-shims-v4.d.ts", shim);
+
+	const system = tsvfs.createSystem(fsmap);
+	const cache = createCacheStorage(system);
+
+	// const debug_system: ts.System = {
+	//   ...system,
+	//   fileExists(p){
+	// 		const r = system.fileExists(p);
+	// 		console.log("fileexists", p, "=>", r);
+	// 		return r;
+	// 	},
+	// 	readFile (p) {
+	// 		const r = system.readFile(p);
+	// 		console.log("readfile", p, "=>", r ? "found" : "not found");
+	// 		return r;
+	// 	},
+	// 	readDirectory (path, extensions, exclude, include, depth) {
+	// 		const r = system.readDirectory(path, extensions, exclude, include, depth);
+	// 		console.log("readDirectory", path, "=>", r);
+	// 		return r;
+	// 	},
+	// 	getCurrentDirectory() {
+	// 		const r = system.getCurrentDirectory();
+	// 		console.log("getCurrentDirectory", "=>", r);
+	// 		return r;
+	// 	},
+	// 	directoryExists(p) {
+	// 		const r = system.directoryExists(p);
+	// 		console.log("directoryExists", p, "=>", r);
+	// 		return r;
+	// 	},
+	// }
+
+	return (source: string) => {
+		cache.delete("/src/Demo.svelte.tsx");
+		const parsed = parse(source, {
+			cache,
+			filepath: "/src/Demo.svelte",
+			system: system,
+			host: tsvfs.createVirtualCompilerHost(system, {}, ts).compilerHost,
+		});
+		return encode(parsed, { indent: 2 });
+	};
+}

--- a/apps/docs/src/routes/demo-playground/initial.txt
+++ b/apps/docs/src/routes/demo-playground/initial.txt
@@ -1,10 +1,10 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
   let { name, age }: {
+    children: Snippet
     /** Your name */
     name?: string,
     /** Your age */
-    name?: string,
-    children: Snippet
+    age?: number,
   } = $props();
 </script>

--- a/apps/docs/src/routes/demo-playground/initial.txt
+++ b/apps/docs/src/routes/demo-playground/initial.txt
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  let { name, age }: {
+    /** Your name */
+    name?: string,
+    /** Your age */
+    name?: string,
+    children: Snippet
+  } = $props();
+</script>

--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -5,6 +5,10 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
 	resolve: {
 		alias: {
+			// Because `svelte2tsx` relies on "node:path", we need to polyfill `node:path` with `pathe`.
+			// 
+			// TODO: Remove this alias when we transition away from `svelte2tsx`.
+			// Discussion: https://github.com/svelte-docgen/svelte-docgen/pull/45/files#r1894924147
 			"path": "pathe",
 			"node:path": "pathe",
 		},

--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -3,6 +3,13 @@ import { sveltepress } from "@sveltepress/vite";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+	resolve: {
+		alias: {
+			"path": "pathe",
+			"node:path": "pathe",
+		},
+	},
+
 	plugins: [
 		sveltepress({
 			siteConfig: {
@@ -17,6 +24,10 @@ export default defineConfig({
 					{
 						title: "Docs",
 						to: "/docs/",
+					},
+					{
+						title: "Demo Playground",
+						to: "/demo-playground/",
 					},
 					{
 						title: "Examples",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"typedoc-plugin-mdn-links": "4.0.4",
 		"typescript": "catalog:",
 		"typescript-eslint": "^8.18.1",
-		"vite": "^6.0.5",
+		"vite": "^catalog:",
 		"vitest": "2.1.8"
 	},
 	"pnpm": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"typedoc-plugin-mdn-links": "4.0.4",
 		"typescript": "catalog:",
 		"typescript-eslint": "^8.18.1",
-		"vite": "^catalog:",
+		"vite": "catalog:",
 		"vitest": "2.1.8"
 	},
 	"pnpm": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"eslint-config-prettier": "^9.1.0",
 		"eslint-plugin-svelte": "^2.46.1",
 		"globals": "^15.14.0",
+		"pathe": "^1.1.2",
 		"prettier": "^3.4.2",
 		"prettier-plugin-svelte": "^3.3.2",
 		"serve": "14.2.4",
@@ -49,12 +50,12 @@
 		"typedoc-plugin-mdn-links": "4.0.4",
 		"typescript": "catalog:",
 		"typescript-eslint": "^8.18.1",
-		"vite": "catalog:",
+		"vite": "^6.0.5",
 		"vitest": "2.1.8"
 	},
 	"pnpm": {
 		"overrides": {
-			"vite": "catalog:",
+			"vite": "^6.0.5",
 			"@sveltejs/vite-plugin-svelte": "^5.0.0"
 		}
 	}

--- a/packages/extractor/package.json
+++ b/packages/extractor/package.json
@@ -85,7 +85,7 @@
 	},
 	"dependencies": {
 		"@types/estree": "^1.0.6",
-		"svelte2tsx": "^0.7.26",
+		"svelte2tsx": "^0.7.31",
 		"zimmerframe": "^1.1.2"
 	},
 	"devDependencies": {

--- a/packages/extractor/src/cache.js
+++ b/packages/extractor/src/cache.js
@@ -1,29 +1,5 @@
 import ts from "typescript";
 
-import { IS_BROWSER } from "./util.js";
-
-/**
- * @internal
- * Get the URI of the module, with environment in mind. Whether is it browser or other JavaScript runtime.
- * @param {string} specifier
- * @returns {URL}
- */
-function get_module_url(specifier) {
-	if (IS_BROWSER) {
-		return new URL(specifier, `file://${globalThis.window.location.href}`);
-	}
-	if (globalThis.process?.env.VITEST) {
-		// @ts-expect-error FIXME: Ugly workaround for `import.meta.resolve` not working in Vitest: https://github.com/vitest-dev/vitest/issues/6953
-		//eslint-disable-next-line no-undef
-		__vite_ssr_import_meta__.resolve = (path) =>
-			globalThis
-				// @ts-expect-error FIXME: 👆
-				.createRequire(import.meta.url)
-				.resolve(path);
-	}
-	return new URL(`file://${import.meta.resolve(specifier)}`);
-}
-
 /**
  * @typedef CachedFile
  * @prop {Date} [last_modified]
@@ -37,8 +13,6 @@ class Cache {
 	#cached = new Map();
 	/** @type {ts.Program | undefined} */
 	program;
-	/** @type {Set<string>} */
-	root_names = new Set([get_module_url("svelte2tsx/svelte-shims-v4.d.ts").pathname]);
 	/** @type {ts.System} */
 	#system;
 

--- a/packages/extractor/src/cache.js
+++ b/packages/extractor/src/cache.js
@@ -2,19 +2,19 @@
 // Find a better workaround.
 // Current issue: https://github.com/vitest-dev/vitest/issues/6953
 // We want to remove it, for the cross-runtime compatibility.
-import module from "node:module";
+// import module from "node:module";
 
 import ts from "typescript";
 
-/**
- * @param {string} specifier
- * @returns {URL}
- */
-function get_node_module_filepath(specifier) {
-	if (typeof import.meta.resolve === "function") return new URL(import.meta.resolve(specifier));
-	const require = module.createRequire(import.meta.url);
-	return new URL(`file://${require.resolve(specifier)}`);
-}
+// /**
+//  * @param {string} specifier
+//  * @returns {URL}
+//  */
+// function get_node_module_filepath(specifier) {
+// 	if (typeof import.meta.resolve === "function") return new URL(import.meta.resolve(specifier));
+// 	const require = module.createRequire(import.meta.url);
+// 	return new URL(`file://${require.resolve(specifier)}`);
+// }
 
 /**
  * @returns {string[]}
@@ -22,7 +22,8 @@ function get_node_module_filepath(specifier) {
 function create_default_root_names() {
 	return [
 		//
-		get_node_module_filepath("svelte2tsx/svelte-shims-v4.d.ts").pathname,
+		////get_node_module_filepath("svelte2tsx/svelte-shims-v4.d.ts").pathname,
+		"/svelte2tsx/svelte-shims-v4.d.ts",
 	];
 }
 
@@ -41,6 +42,14 @@ class Cache {
 	program;
 	/** @type {Set<string>} */
 	root_names = new Set(create_default_root_names());
+	/** @type {ts.System} */
+	system;
+
+	/** @param {ts.System | undefined} system */
+	constructor(system) {
+		this.system = system ?? ts.sys;
+	}
+
 	/**
 	 * @param {string} filepath
 	 * @returns {boolean}
@@ -55,8 +64,15 @@ class Cache {
 	 */
 	get(filepath) {
 		const cached = this.#cached.get(filepath);
-		const last_modified = ts.sys.getModifiedTime?.(filepath);
+		const last_modified = this.system.getModifiedTime?.(filepath);
 		if (cached?.last_modified?.getTime() === last_modified?.getTime()) return cached;
+	}
+
+	/**
+	 * @param {string} filepath
+	 */
+	delete(filepath) {
+		this.#cached.delete(filepath);
 	}
 
 	/**
@@ -67,12 +83,15 @@ class Cache {
 	set(filepath, updated) {
 		const cached = this.#cached.get(filepath);
 		if (cached) return { ...cached, ...updated };
-		const last_modified = ts.sys.getModifiedTime?.(filepath);
+		const last_modified = this.system?.getModifiedTime?.(filepath);
 		const value = { ...updated, last_modified };
 		this.#cached.set(filepath, value);
 		return value;
 	}
 }
 
-/** @returns {Cache} */
-export const createCacheStorage = () => new Cache();
+/**
+ * @param {ts.System} [system]
+ * @returns {Cache}
+ * */
+export const createCacheStorage = (system) => new Cache(system);

--- a/packages/extractor/src/cache.js
+++ b/packages/extractor/src/cache.js
@@ -43,11 +43,11 @@ class Cache {
 	/** @type {Set<string>} */
 	root_names = new Set(create_default_root_names());
 	/** @type {ts.System} */
-	system;
+	#system;
 
 	/** @param {ts.System | undefined} system */
 	constructor(system) {
-		this.system = system ?? ts.sys;
+		this.#system = system ?? ts.sys;
 	}
 
 	/**
@@ -64,7 +64,7 @@ class Cache {
 	 */
 	get(filepath) {
 		const cached = this.#cached.get(filepath);
-		const last_modified = this.system.getModifiedTime?.(filepath);
+		const last_modified = this.#system.getModifiedTime?.(filepath);
 		if (cached?.last_modified?.getTime() === last_modified?.getTime()) return cached;
 	}
 
@@ -83,7 +83,7 @@ class Cache {
 	set(filepath, updated) {
 		const cached = this.#cached.get(filepath);
 		if (cached) return { ...cached, ...updated };
-		const last_modified = this.system?.getModifiedTime?.(filepath);
+		const last_modified = this.#system?.getModifiedTime?.(filepath);
 		const value = { ...updated, last_modified };
 		this.#cached.set(filepath, value);
 		return value;

--- a/packages/extractor/src/compiler.js
+++ b/packages/extractor/src/compiler.js
@@ -10,8 +10,6 @@ import { svelte2tsx } from "svelte2tsx";
 export class Compiler {
 	/** @type {ReturnType<typeof svelte2tsx>} */
 	tsx;
-	/** @type {TSXFilepath} */
-	filepath;
 
 	/**
 	 * @param {Source} source
@@ -19,7 +17,6 @@ export class Compiler {
 	 * @param {Options} options
 	 */
 	constructor(source, parser, options) {
-		this.filepath = `${options.filepath}.tsx`;
 		this.tsx = this.#compile_to_tsx(source, parser, options.filepath);
 	}
 

--- a/packages/extractor/src/compiler.test.ts
+++ b/packages/extractor/src/compiler.test.ts
@@ -21,14 +21,6 @@ const EXAMPLE = `
 `;
 
 describe(Compiler.name, () => {
-	describe("filepath", () => {
-		it("should add `.tsx` extension to the original Svelte filepath", ({ expect }) => {
-			const { filepath } = new Compiler(EXAMPLE, new Parser(EXAMPLE), create_options("filepath.svelte"));
-			expect(filepath).toMatchInlineSnapshot(`"filepath.svelte.tsx"`);
-			expect(filepath.endsWith(".tsx")).toBe(true);
-		});
-	});
-
 	describe("tsx.code", () => {
 		it("returns compiled code with `svelte2tsx`", ({ expect }) => {
 			const { tsx } = new Compiler(EXAMPLE, new Parser(EXAMPLE), create_options("tsx-code.svelte"));

--- a/packages/extractor/src/extractor/mod.js
+++ b/packages/extractor/src/extractor/mod.js
@@ -1,42 +1,15 @@
-import { IS_NODE_LIKE } from "../util.js";
+import ts from "typescript";
 
-/**
- * @internal
- * Get the file path to the module, with vfs environments in mind.
- * @param {string} specifier
- * @returns {URL}
- */
-function get_module_url(specifier) {
-	if (!IS_NODE_LIKE) {
-		return new URL(`file:///node_modules/${specifier}`); // Refer to virtual file system
-	}
-	if (globalThis.process?.env.VITEST) {
-		// @ts-expect-error FIXME: Ugly workaround for `import.meta.resolve` not working in Vitest: https://github.com/vitest-dev/vitest/issues/6953
-		//eslint-disable-next-line no-undef
-		__vite_ssr_import_meta__.resolve = (path) =>
-			"file://" +
-			globalThis
-				// @ts-expect-error FIXME: 👆
-				.createRequire(import.meta.url)
-				.resolve(path);
-	}
-	return new URL(import.meta.resolve(specifier));
-}
+import { ComponentDocExtractor } from "./component-doc.js";
+import { Compiler } from "../compiler.js";
+import { Options } from "../options.js";
+import { Parser } from "../parser.js";
 
 /**
  * @import { Tag } from "./component-doc.js";
  * @import { Source } from "../util.js";
  * @import { createCacheStorage } from "../cache.js";
  */
-
-import path from "pathe";
-
-import ts from "typescript";
-
-import { Compiler } from "../compiler.js";
-import { Options } from "../options.js";
-import { Parser } from "../parser.js";
-import { ComponentDocExtractor } from "./component-doc.js";
 
 class Extractor {
 	/** @type {Source} */
@@ -210,83 +183,24 @@ class Extractor {
 	 */
 	#create_program() {
 		const program = ts.createProgram({
-			rootNames: [get_module_url("svelte2tsx/svelte-shims-v4.d.ts").pathname, this.compiler.filepath],
-			options: this.#get_ts_options(),
+			rootNames: [this.#options.shims_path, this.#options.tsx_filepath],
+			options: this.#options.get_ts_options(),
 			host: this.#create_host(),
 			oldProgram: this.#cache.program,
 		});
 		return program;
 	}
 
-	/** @returns {ts.CompilerOptions} */
-	#get_ts_options() {
-		const cached = this.#cache.get(this.compiler.filepath)?.options;
-		if (cached) return cached;
-		const options = this.#build_ts_options();
-		this.#cache.set(this.compiler.filepath, { options });
-		return options;
-	}
-
-	/** @type {ts.CompilerOptions} */
-	#forced_ts_options = {
-		allowJs: true,
-		checkJs: true,
-		noEmit: true,
-		skipDefaultLibCheck: true,
-		skipLibCheck: true,
-		sourceMap: false,
-		strict: true,
-	};
-
-	/** @returns {ts.CompilerOptions} */
-	#build_ts_options() {
-		const configpath = this.#find_ts_config_path();
-		if (configpath) {
-			const config_file = ts.readConfigFile(configpath, this.system.readFile);
-			const parsed = ts.parseJsonConfigFileContent(
-				config_file.config,
-				this.system,
-				path.dirname(configpath),
-				undefined,
-				configpath,
-				undefined,
-				[
-					{
-						extension: "svelte",
-						isMixedContent: true,
-						scriptKind: ts.ScriptKind.Deferred,
-					},
-				],
-			);
-			return {
-				...parsed.options,
-				...this.#forced_ts_options,
-			};
-			// TODO: Create a warning when tsconfig.json `compilerOptions.lib` doesn't include DOM
-		}
-		return this.#forced_ts_options;
-	}
-
-	/**
-	 * @returns {string | undefined}
-	 */
-	#find_ts_config_path() {
-		return (
-			ts.findConfigFile(this.compiler.filepath, this.system.fileExists) ||
-			ts.findConfigFile(this.compiler.filepath, this.system.fileExists, "jsconfig.json")
-		);
-	}
-
 	/**
 	 * @returns {ts.CompilerHost}
 	 */
 	#create_host() {
-		const default_host = this.#options.host || ts.createCompilerHost(this.#get_ts_options());
+		const default_host = this.#options.host || ts.createCompilerHost(this.#options.get_ts_options());
 		/** @type {Partial<ts.CompilerHost>} */
 		const overridden_methods = {
 			fileExists: (filepath) => {
 				if (this.#cache.has(filepath)) return true;
-				if (filepath === this.compiler.filepath) return true;
+				if (filepath === this.#options.tsx_filepath) return true;
 				return default_host.fileExists(filepath);
 			},
 			getSourceFile: (filepath, language_version, on_error) => {
@@ -294,10 +208,10 @@ class Extractor {
 				if (cached?.source) return cached.source;
 				/** @type {ts.SourceFile | undefined} */
 				let source;
-				if (filepath === this.compiler.filepath) {
+				if (filepath === this.#options.tsx_filepath) {
 					const content = this.compiler.tsx.code;
 					source = ts.createSourceFile(
-						this.compiler.filepath,
+						this.#options.tsx_filepath,
 						content,
 						language_version,
 						true,
@@ -316,7 +230,7 @@ class Extractor {
 				if (cached?.content) return cached.content;
 				/** @type {string | undefined} */
 				let content;
-				if (filepath === this.compiler.filepath) content = this.compiler.tsx.code;
+				if (filepath === this.#options.tsx_filepath) content = this.compiler.tsx.code;
 				else content = default_host.readFile(filepath);
 				if (content) this.#cache.set(filepath, { content });
 				return content;
@@ -345,13 +259,13 @@ class Extractor {
 	/** @returns {ts.SourceFile} */
 	get #source_file() {
 		if (this.#cached_source_file) return this.#cached_source_file;
-		const from_cache = this.#cache.get(this.compiler.filepath)?.source;
+		const from_cache = this.#cache.get(this.#options.tsx_filepath)?.source;
 		if (from_cache) return from_cache;
-		const from_program = this.#program.getSourceFile(this.compiler.filepath);
+		const from_program = this.#program.getSourceFile(this.#options.tsx_filepath);
 		//O TODO: Document it
 		if (!from_program)
-			throw new Error(`Source file could not be found by TypeScript program: ${this.compiler.filepath}`);
-		this.#cached_source_file = this.#cache.set(this.compiler.filepath, {
+			throw new Error(`Source file could not be found by TypeScript program: ${this.#options.tsx_filepath}`);
+		this.#cached_source_file = this.#cache.set(this.#options.tsx_filepath, {
 			source: from_program,
 		}).source;
 		return from_program;

--- a/packages/extractor/src/extractor/mod.js
+++ b/packages/extractor/src/extractor/mod.js
@@ -196,10 +196,10 @@ class Extractor {
 
 	/** @returns {ts.CompilerOptions} */
 	#get_ts_options() {
-		const cached = this.#cache.get(this.source)?.options;
+		const cached = this.#cache.get(this.compiler.filepath)?.options;
 		if (cached) return cached;
 		const options = this.#build_ts_options();
-		this.#cache.set(this.source, { options });
+		this.#cache.set(this.compiler.filepath, { options });
 		return options;
 	}
 

--- a/packages/extractor/src/extractor/mod.js
+++ b/packages/extractor/src/extractor/mod.js
@@ -209,9 +209,8 @@ class Extractor {
 	 * @returns {ts.Program}
 	 */
 	#create_program() {
-		const root_names = [get_module_url("svelte2tsx/svelte-shims-v4.d.ts").pathname, this.compiler.filepath];
 		const program = ts.createProgram({
-			rootNames: root_names,
+			rootNames: [get_module_url("svelte2tsx/svelte-shims-v4.d.ts").pathname, this.compiler.filepath],
 			options: this.#get_ts_options(),
 			host: this.#create_host(),
 			oldProgram: this.#cache.program,

--- a/packages/extractor/src/extractor/mod.js
+++ b/packages/extractor/src/extractor/mod.js
@@ -4,7 +4,7 @@
  * @import { createCacheStorage } from "../cache.js";
  */
 
-import path from "node:path";
+import path from "pathe";
 
 import ts from "typescript";
 
@@ -22,6 +22,8 @@ class Extractor {
 	parser;
 	/** @type {Compiler} */
 	compiler;
+	/** @type {ts.System} */
+	system;
 
 	/**
 	 * @param {Source} source
@@ -30,6 +32,7 @@ class Extractor {
 	constructor(source, options) {
 		this.source = source;
 		this.#options = new Options(options);
+		this.system = this.#options.system;
 		this.parser = new Parser(this.source);
 		this.compiler = new Compiler(this.source, this.parser, this.#options);
 	}
@@ -215,10 +218,10 @@ class Extractor {
 	#build_ts_options() {
 		const configpath = this.#find_ts_config_path();
 		if (configpath) {
-			const config_file = ts.readConfigFile(configpath, ts.sys.readFile);
+			const config_file = ts.readConfigFile(configpath, this.system.readFile);
 			const parsed = ts.parseJsonConfigFileContent(
 				config_file.config,
-				ts.sys,
+				this.system,
 				path.dirname(configpath),
 				undefined,
 				configpath,
@@ -245,8 +248,8 @@ class Extractor {
 	 */
 	#find_ts_config_path() {
 		return (
-			ts.findConfigFile(this.compiler.filepath, ts.sys.fileExists) ||
-			ts.findConfigFile(this.compiler.filepath, ts.sys.fileExists, "jsconfig.json")
+			ts.findConfigFile(this.compiler.filepath, this.system.fileExists) ||
+			ts.findConfigFile(this.compiler.filepath, this.system.fileExists, "jsconfig.json")
 		);
 	}
 
@@ -254,7 +257,7 @@ class Extractor {
 	 * @returns {ts.CompilerHost}
 	 */
 	#create_host() {
-		const default_host = ts.createCompilerHost(this.#get_ts_options());
+		const default_host = this.#options.host || ts.createCompilerHost(this.#get_ts_options());
 		/** @type {Partial<ts.CompilerHost>} */
 		const overridden_methods = {
 			fileExists: (filepath) => {

--- a/packages/extractor/src/extractor/mod.js
+++ b/packages/extractor/src/extractor/mod.js
@@ -31,8 +31,8 @@ class Extractor {
 	 */
 	constructor(source, options) {
 		this.source = source;
+		this.system = options.system;
 		this.#options = new Options(options);
-		this.system = this.#options.system;
 		this.parser = new Parser(this.source);
 		this.compiler = new Compiler(this.source, this.parser, this.#options);
 	}

--- a/packages/extractor/src/options.js
+++ b/packages/extractor/src/options.js
@@ -1,9 +1,12 @@
+import path from "pathe";
+import ts from "typescript";
+
+import { createCacheStorage } from "./cache.js";
+import { IS_NODE_LIKE } from "./util.js";
+
 /**
  * @import { SvelteFilepath, TSXFilepath } from "./util.js";
  */
-
-import ts from "typescript";
-import { createCacheStorage } from "./cache.js";
 
 /** @typedef {Partial<Options> & { filepath?: SvelteFilepath | (string & {}) }} UserOptions */
 
@@ -12,12 +15,12 @@ export class Options {
 	cache;
 	/** @type {SvelteFilepath} */
 	filepath;
-	/** @type {TSXFilepath} */
-	tsx_filepath;
 	/** @type {ts.System} */
 	system;
 	/** @type {ts.CompilerHost | undefined} */
 	host;
+	/** @type {string} */
+	shims_path = get_module_url("svelte2tsx/svelte-shims-v4.d.ts").pathname;
 
 	/** @param {UserOptions} user_options */
 	constructor(user_options) {
@@ -29,7 +32,11 @@ export class Options {
 			this.#validate_filepath(filepath);
 			this.filepath = filepath;
 		} else this.filepath = this.#random_filepath;
-		this.tsx_filepath = `${this.filepath}.tsx`;
+	}
+
+	/** @return {TSXFilepath} */
+	get tsx_filepath() {
+		return `${this.filepath}.tsx`;
 	}
 
 	/**
@@ -61,4 +68,86 @@ export class Options {
 		const random_str = `${Date.now()}-${Math.random().toString(36).substring(2, 10)}`;
 		return `${random_str}.svelte`;
 	}
+
+	/** @returns {ts.CompilerOptions} */
+	get_ts_options() {
+		const cached = this.cache.get(this.tsx_filepath)?.options;
+		if (cached) return cached;
+		const options = this.#build_ts_options();
+		this.cache.set(this.tsx_filepath, { options });
+		return options;
+	}
+
+	/** @type {ts.CompilerOptions} */
+	#forced_ts_options = {
+		allowJs: true,
+		checkJs: true,
+		noEmit: true,
+		skipDefaultLibCheck: true,
+		skipLibCheck: true,
+		sourceMap: false,
+		strict: true,
+	};
+
+	/** @returns {ts.CompilerOptions} */
+	#build_ts_options() {
+		const configpath = this.#find_ts_config_path();
+		if (configpath) {
+			const config_file = ts.readConfigFile(configpath, this.system.readFile);
+			const parsed = ts.parseJsonConfigFileContent(
+				config_file.config,
+				this.system,
+				path.dirname(configpath),
+				undefined,
+				configpath,
+				undefined,
+				[
+					{
+						extension: "svelte",
+						isMixedContent: true,
+						scriptKind: ts.ScriptKind.Deferred,
+					},
+				],
+			);
+			return {
+				...parsed.options,
+				...this.#forced_ts_options,
+			};
+			// TODO: Create a warning when tsconfig.json `compilerOptions.lib` doesn't include DOM
+		}
+		return this.#forced_ts_options;
+	}
+
+	/**
+	 * @returns {string | undefined}
+	 */
+	#find_ts_config_path() {
+		return (
+			ts.findConfigFile(this.tsx_filepath, this.system.fileExists) ||
+			ts.findConfigFile(this.tsx_filepath, this.system.fileExists, "jsconfig.json")
+		);
+	}
+}
+
+/**
+ * @internal
+ * Get the file path to the module, with vfs environments in mind.
+ * @param {string} specifier
+ * @returns {URL}
+ */
+function get_module_url(specifier) {
+	if (!IS_NODE_LIKE) {
+		return new URL(`file:///node_modules/${specifier}`); // file in virtual file system
+	}
+	if (globalThis.process?.env.VITEST) {
+		// @ts-expect-error FIXME: Ugly workaround for `import.meta.resolve` not working in Vitest: https://github.com/vitest-dev/vitest/issues/6953
+		//eslint-disable-next-line no-undef
+		__vite_ssr_import_meta__.resolve = (path) =>
+			"file://" +
+			globalThis
+				// @ts-expect-error FIXME: 👆
+				.createRequire(import.meta.url)
+				.resolve(path);
+	}
+	return new URL(import.meta.resolve(specifier));
 }

--- a/packages/extractor/src/options.js
+++ b/packages/extractor/src/options.js
@@ -2,6 +2,7 @@
  * @import { SvelteFilepath } from "./util.js";
  */
 
+import ts from "typescript";
 import { createCacheStorage } from "./cache.js";
 
 /** @typedef {Partial<Options> & { filepath?: SvelteFilepath | (string & {}) }} UserOptions */
@@ -11,10 +12,16 @@ export class Options {
 	cache;
 	/** @type {SvelteFilepath} */
 	filepath;
+	/** @type {ts.System} */
+	system;
+	/** @type {ts.CompilerHost | undefined} */
+	host;
 
 	/** @param {UserOptions} user_options */
 	constructor(user_options) {
-		this.cache = user_options.cache ?? createCacheStorage();
+		this.system = user_options.system ?? ts.sys;
+		this.cache = user_options.cache ?? createCacheStorage(this.system);
+		this.host = user_options.host;
 		if (user_options.filepath) {
 			const filepath = this.#parse_filepath(user_options.filepath);
 			this.#validate_filepath(filepath);

--- a/packages/extractor/src/options.js
+++ b/packages/extractor/src/options.js
@@ -1,5 +1,5 @@
 /**
- * @import { SvelteFilepath } from "./util.js";
+ * @import { SvelteFilepath, TSXFilepath } from "./util.js";
  */
 
 import ts from "typescript";
@@ -12,6 +12,8 @@ export class Options {
 	cache;
 	/** @type {SvelteFilepath} */
 	filepath;
+	/** @type {TSXFilepath} */
+	tsx_filepath;
 	/** @type {ts.System} */
 	system;
 	/** @type {ts.CompilerHost | undefined} */
@@ -27,6 +29,7 @@ export class Options {
 			this.#validate_filepath(filepath);
 			this.filepath = filepath;
 		} else this.filepath = this.#random_filepath;
+		this.tsx_filepath = `${this.filepath}.tsx`;
 	}
 
 	/**

--- a/packages/extractor/src/util.js
+++ b/packages/extractor/src/util.js
@@ -13,4 +13,4 @@
  * @typedef {`${SvelteFilepath}.tsx`} TSXFilepath
  */
 
-export {};
+export const IS_BROWSER = globalThis.window !== undefined;

--- a/packages/extractor/src/util.js
+++ b/packages/extractor/src/util.js
@@ -13,4 +13,4 @@
  * @typedef {`${SvelteFilepath}.tsx`} TSXFilepath
  */
 
-export const IS_BROWSER = globalThis.window !== undefined;
+export const IS_NODE_LIKE = globalThis.process?.cwd !== undefined;

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -94,7 +94,7 @@
 	"dependencies": {
 		"@hono/node-server": "^1.13.7",
 		"@hono/valibot-validator": "^0.5.1",
-		"hono": "^4.6.13",
+		"hono": "^4.6.14",
 		"valibot": "catalog:"
 	},
 	"devDependencies": {

--- a/packages/svelte-docgen/package.json
+++ b/packages/svelte-docgen/package.json
@@ -88,8 +88,8 @@
 	},
 	"dependencies": {
 		"@svelte-docgen/extractor": "workspace:*",
-		"valibot": "catalog:",
-		"typescript": "catalog:"
+		"typescript": "^5.0.0",
+		"valibot": "catalog:"
 	},
 	"devDependencies": {
 		"dts-buddy": "catalog:"

--- a/packages/svelte-docgen/package.json
+++ b/packages/svelte-docgen/package.json
@@ -88,13 +88,13 @@
 	},
 	"dependencies": {
 		"@svelte-docgen/extractor": "workspace:*",
-		"valibot": "catalog:"
+		"valibot": "catalog:",
+		"typescript": "catalog:"
 	},
 	"devDependencies": {
 		"dts-buddy": "catalog:"
 	},
 	"peerDependencies": {
-		"svelte": "catalog:",
-		"typescript": "catalog:"
+		"svelte": "catalog:"
 	}
 }

--- a/packages/svelte-docgen/src/analyzer/prop.js
+++ b/packages/svelte-docgen/src/analyzer/prop.js
@@ -2,7 +2,7 @@
  * @import * as Doc from "../doc/type.ts";
  */
 
-import path from "node:path";
+import path from "pathe";
 
 class PropAnalyzer {
 	/** @type {Doc.Prop} */

--- a/packages/svelte-docgen/src/analyzer/prop.test.ts
+++ b/packages/svelte-docgen/src/analyzer/prop.test.ts
@@ -75,6 +75,20 @@ describe(analyzeProperty.name, () => {
 			if (custom) {
 				const analyzer = analyzeProperty(custom);
 				expect(analyzer.isExtendedBySvelte).toBe(false);
+				expect(custom).toMatchInlineSnapshot(`
+					{
+					  "isBindable": false,
+					  "isExtended": true,
+					  "isOptional": false,
+					  "sources": Set {
+					    "/packages/svelte-docgen/tests/custom-extended.ts",
+					  },
+					  "tags": [],
+					  "type": {
+					    "kind": "string",
+					  },
+					}
+				`);
 			}
 		});
 	});

--- a/packages/svelte-docgen/src/parser/mod.js
+++ b/packages/svelte-docgen/src/parser/mod.js
@@ -43,7 +43,7 @@ class Parser {
 	constructor(source, options) {
 		this.#options = options;
 		this.#extractor = extract(source, this.#options);
-		this.#root_path_url = get_root_path_url();
+		this.#root_path_url = get_root_path_url(this.#options.system);
 	}
 
 	/** @returns {ParsedComponent} */

--- a/packages/svelte-docgen/src/shared.js
+++ b/packages/svelte-docgen/src/shared.js
@@ -172,6 +172,7 @@ export function get_sources(declarations, root_path_url) {
  */
 export function get_root_path_url(sys) {
 	if (!IS_NODE_LIKE) {
+		// Set the root of the virtual file system (VFS) as the root
 		return new URL("file:///");
 	}
 	let directory = path.resolve(process.cwd());

--- a/packages/svelte-docgen/src/shared.js
+++ b/packages/svelte-docgen/src/shared.js
@@ -2,11 +2,13 @@
  * @import { extract } from "@svelte-docgen/extractor";
  */
 
-// import fs from "node:fs";
-// import url from "node:url";
-// import path from "pathe";
+import fs from "node:fs";
+import url from "node:url";
+import path from "pathe";
 
 import ts from "typescript";
+
+const IS_NODE_LIKE = globalThis.process?.cwd !== undefined;
 
 /**
  * @internal
@@ -170,33 +172,36 @@ export function get_sources(declarations, root_path_url) {
  * @throws {Error} If it cannot find nearest `package.json` file if project isn't a monorepo.
  */
 export function get_root_path_url() {
-	return new URL("file:///");
-	// let directory = path.resolve(process.cwd());
-	// const { root } = path.parse(directory);
-	// /** @type {string | undefined} */
-	// let package_json_filepath;
-	// while (directory && directory !== root) {
-	// 	try {
-	// 		const pnpm_workspace_filepath = path.join(directory, "pnpm-workspace.yaml");
-	// 		const stats = fs.statSync(pnpm_workspace_filepath, { throwIfNoEntry: false });
-	// 		if (stats?.isFile()) return url.pathToFileURL(directory);
-	// 	} catch {
-	// 		/** Is okay, do nothing. Check for other possibilities. */
-	// 	}
-	// 	try {
-	// 		package_json_filepath = path.join(directory, "package.json");
-	// 		const stats = fs.statSync(package_json_filepath, { throwIfNoEntry: false });
-	// 		if (stats?.isFile()) {
-	// 			const content = fs.readFileSync(package_json_filepath, "utf-8");
-	// 			if (JSON.parse(content).workspaces) return url.pathToFileURL(directory);
-	// 		}
-	// 	} catch {
-	// 		/** Is okay, do nothing. Check parent up. */
-	// 	}
-	// 	// NOTE: This goes root up
-	// 	directory = path.dirname(directory);
-	// }
-	// if (package_json_filepath) return url.pathToFileURL(path.dirname(package_json_filepath));
-	// // TODO: Document error
-	// throw new Error("Could not determine the the root path.");
+	if (!IS_NODE_LIKE) {
+		return new URL("file:///");
+	}
+
+	let directory = path.resolve(process.cwd());
+	const { root } = path.parse(directory);
+	/** @type {string | undefined} */
+	let package_json_filepath;
+	while (directory && directory !== root) {
+		try {
+			const pnpm_workspace_filepath = path.join(directory, "pnpm-workspace.yaml");
+			const stats = fs.statSync(pnpm_workspace_filepath, { throwIfNoEntry: false });
+			if (stats?.isFile()) return url.pathToFileURL(directory);
+		} catch {
+			/** Is okay, do nothing. Check for other possibilities. */
+		}
+		try {
+			package_json_filepath = path.join(directory, "package.json");
+			const stats = fs.statSync(package_json_filepath, { throwIfNoEntry: false });
+			if (stats?.isFile()) {
+				const content = fs.readFileSync(package_json_filepath, "utf-8");
+				if (JSON.parse(content).workspaces) return url.pathToFileURL(directory);
+			}
+		} catch {
+			/** Is okay, do nothing. Check parent up. */
+		}
+		// NOTE: This goes root up
+		directory = path.dirname(directory);
+	}
+	if (package_json_filepath) return url.pathToFileURL(path.dirname(package_json_filepath));
+	// TODO: Document error
+	throw new Error("Could not determine the the root path.");
 }

--- a/packages/svelte-docgen/src/shared.js
+++ b/packages/svelte-docgen/src/shared.js
@@ -2,9 +2,9 @@
  * @import { extract } from "@svelte-docgen/extractor";
  */
 
-import fs from "node:fs";
-import path from "node:path";
-import url from "node:url";
+// import fs from "node:fs";
+// import url from "node:url";
+// import path from "pathe";
 
 import ts from "typescript";
 
@@ -170,32 +170,33 @@ export function get_sources(declarations, root_path_url) {
  * @throws {Error} If it cannot find nearest `package.json` file if project isn't a monorepo.
  */
 export function get_root_path_url() {
-	let directory = path.resolve(process.cwd());
-	const { root } = path.parse(directory);
-	/** @type {string | undefined} */
-	let package_json_filepath;
-	while (directory && directory !== root) {
-		try {
-			const pnpm_workspace_filepath = path.join(directory, "pnpm-workspace.yaml");
-			const stats = fs.statSync(pnpm_workspace_filepath, { throwIfNoEntry: false });
-			if (stats?.isFile()) return url.pathToFileURL(directory);
-		} catch {
-			/** Is okay, do nothing. Check for other possibilities. */
-		}
-		try {
-			package_json_filepath = path.join(directory, "package.json");
-			const stats = fs.statSync(package_json_filepath, { throwIfNoEntry: false });
-			if (stats?.isFile()) {
-				const content = fs.readFileSync(package_json_filepath, "utf-8");
-				if (JSON.parse(content).workspaces) return url.pathToFileURL(directory);
-			}
-		} catch {
-			/** Is okay, do nothing. Check parent up. */
-		}
-		// NOTE: This goes root up
-		directory = path.dirname(directory);
-	}
-	if (package_json_filepath) return url.pathToFileURL(path.dirname(package_json_filepath));
-	// TODO: Document error
-	throw new Error("Could not determine the the root path.");
+	return new URL("file:///");
+	// let directory = path.resolve(process.cwd());
+	// const { root } = path.parse(directory);
+	// /** @type {string | undefined} */
+	// let package_json_filepath;
+	// while (directory && directory !== root) {
+	// 	try {
+	// 		const pnpm_workspace_filepath = path.join(directory, "pnpm-workspace.yaml");
+	// 		const stats = fs.statSync(pnpm_workspace_filepath, { throwIfNoEntry: false });
+	// 		if (stats?.isFile()) return url.pathToFileURL(directory);
+	// 	} catch {
+	// 		/** Is okay, do nothing. Check for other possibilities. */
+	// 	}
+	// 	try {
+	// 		package_json_filepath = path.join(directory, "package.json");
+	// 		const stats = fs.statSync(package_json_filepath, { throwIfNoEntry: false });
+	// 		if (stats?.isFile()) {
+	// 			const content = fs.readFileSync(package_json_filepath, "utf-8");
+	// 			if (JSON.parse(content).workspaces) return url.pathToFileURL(directory);
+	// 		}
+	// 	} catch {
+	// 		/** Is okay, do nothing. Check parent up. */
+	// 	}
+	// 	// NOTE: This goes root up
+	// 	directory = path.dirname(directory);
+	// }
+	// if (package_json_filepath) return url.pathToFileURL(path.dirname(package_json_filepath));
+	// // TODO: Document error
+	// throw new Error("Could not determine the the root path.");
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,19 +107,19 @@ importers:
     devDependencies:
       '@sveltejs/adapter-cloudflare':
         specifier: ^4.9.0
-        version: 4.9.0(@sveltejs/kit@2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(wrangler@3.96.0(@cloudflare/workers-types@4.20241218.0))
+        version: 4.9.0(@sveltejs/kit@2.14.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(wrangler@3.96.0(@cloudflare/workers-types@4.20241218.0))
       '@sveltejs/kit':
-        specifier: ^2.13.0
-        version: 2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
+        specifier: ^2.14.0
+        version: 2.14.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
       '@sveltejs/vite-plugin-svelte':
-        specifier: ^5.0.0
+        specifier: ^5.0.3
         version: 5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
       '@sveltepress/theme-default':
         specifier: ^5.0.5
-        version: 5.0.5(rbgpjl43s7mzugr5hgnsgubuf4)
+        version: 5.0.5(rwjuugdagobrixgkl2o7udorhm)
       '@sveltepress/vite':
         specifier: ^1.1.2
-        version: 1.1.2(@sveltejs/kit@2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(rollup@2.79.2)(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
+        version: 1.1.2(@sveltejs/kit@2.14.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(rollup@2.79.2)(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
       '@typescript/vfs':
         specifier: ^1.6.0
         version: 1.6.0(typescript@5.7.2)
@@ -988,6 +988,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.24.2':
+    resolution: {integrity: sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.17.19':
     resolution: {integrity: sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==}
     engines: {node: '>=12'}
@@ -1002,6 +1008,12 @@ packages:
 
   '@esbuild/android-arm64@0.24.0':
     resolution: {integrity: sha512-Vsm497xFM7tTIPYK9bNTYJyF/lsP590Qc1WxJdlB6ljCbdZKU9SY8i7+Iin4kyhV/KV5J2rOKsBQbB77Ab7L/w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.24.2':
+    resolution: {integrity: sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -1024,6 +1036,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.24.2':
+    resolution: {integrity: sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.17.19':
     resolution: {integrity: sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==}
     engines: {node: '>=12'}
@@ -1038,6 +1056,12 @@ packages:
 
   '@esbuild/android-x64@0.24.0':
     resolution: {integrity: sha512-t8GrvnFkiIY7pa7mMgJd7p8p8qqYIz1NYiAoKc75Zyv73L3DZW++oYMSHPRarcotTKuSs6m3hTOa5CKHaS02TQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.24.2':
+    resolution: {integrity: sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -1060,6 +1084,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.24.2':
+    resolution: {integrity: sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.17.19':
     resolution: {integrity: sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==}
     engines: {node: '>=12'}
@@ -1074,6 +1104,12 @@ packages:
 
   '@esbuild/darwin-x64@0.24.0':
     resolution: {integrity: sha512-rgtz6flkVkh58od4PwTRqxbKH9cOjaXCMZgWD905JOzjFKW+7EiUObfd/Kav+A6Gyud6WZk9w+xu6QLytdi2OA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.24.2':
+    resolution: {integrity: sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -1096,6 +1132,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.24.2':
+    resolution: {integrity: sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.17.19':
     resolution: {integrity: sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==}
     engines: {node: '>=12'}
@@ -1110,6 +1152,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.24.0':
     resolution: {integrity: sha512-D3H+xh3/zphoX8ck4S2RxKR6gHlHDXXzOf6f/9dbFt/NRBDIE33+cVa49Kil4WUjxMGW0ZIYBYtaGCa2+OsQwQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.24.2':
+    resolution: {integrity: sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -1132,6 +1180,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.24.2':
+    resolution: {integrity: sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.17.19':
     resolution: {integrity: sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==}
     engines: {node: '>=12'}
@@ -1146,6 +1200,12 @@ packages:
 
   '@esbuild/linux-arm@0.24.0':
     resolution: {integrity: sha512-gJKIi2IjRo5G6Glxb8d3DzYXlxdEj2NlkixPsqePSZMhLudqPhtZ4BUrpIuTjJYXxvF9njql+vRjB2oaC9XpBw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.24.2':
+    resolution: {integrity: sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -1168,6 +1228,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.24.2':
+    resolution: {integrity: sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.17.19':
     resolution: {integrity: sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==}
     engines: {node: '>=12'}
@@ -1182,6 +1248,12 @@ packages:
 
   '@esbuild/linux-loong64@0.24.0':
     resolution: {integrity: sha512-0mswrYP/9ai+CU0BzBfPMZ8RVm3RGAN/lmOMgW4aFUSOQBjA31UP8Mr6DDhWSuMwj7jaWOT0p0WoZ6jeHhrD7g==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.24.2':
+    resolution: {integrity: sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -1204,6 +1276,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.24.2':
+    resolution: {integrity: sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.17.19':
     resolution: {integrity: sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==}
     engines: {node: '>=12'}
@@ -1218,6 +1296,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.24.0':
     resolution: {integrity: sha512-HcZh5BNq0aC52UoocJxaKORfFODWXZxtBaaZNuN3PUX3MoDsChsZqopzi5UupRhPHSEHotoiptqikjN/B77mYQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.24.2':
+    resolution: {integrity: sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -1240,6 +1324,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.24.2':
+    resolution: {integrity: sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.17.19':
     resolution: {integrity: sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==}
     engines: {node: '>=12'}
@@ -1254,6 +1344,12 @@ packages:
 
   '@esbuild/linux-s390x@0.24.0':
     resolution: {integrity: sha512-ZcQ6+qRkw1UcZGPyrCiHHkmBaj9SiCD8Oqd556HldP+QlpUIe2Wgn3ehQGVoPOvZvtHm8HPx+bH20c9pvbkX3g==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.24.2':
+    resolution: {integrity: sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -1276,6 +1372,18 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.24.2':
+    resolution: {integrity: sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.24.2':
+    resolution: {integrity: sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.17.19':
     resolution: {integrity: sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==}
     engines: {node: '>=12'}
@@ -1294,6 +1402,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.24.2':
+    resolution: {integrity: sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.23.1':
     resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
     engines: {node: '>=18'}
@@ -1302,6 +1416,12 @@ packages:
 
   '@esbuild/openbsd-arm64@0.24.0':
     resolution: {integrity: sha512-MD9uzzkPQbYehwcN583yx3Tu5M8EIoTD+tUgKF982WYL9Pf5rKy9ltgD0eUgs8pvKnmizxjXZyLt0z6DC3rRXg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.24.2':
+    resolution: {integrity: sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1324,6 +1444,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.24.2':
+    resolution: {integrity: sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/sunos-x64@0.17.19':
     resolution: {integrity: sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==}
     engines: {node: '>=12'}
@@ -1338,6 +1464,12 @@ packages:
 
   '@esbuild/sunos-x64@0.24.0':
     resolution: {integrity: sha512-jVzdzsbM5xrotH+W5f1s+JtUy1UWgjU0Cf4wMvffTB8m6wP5/kx0KiaLHlbJO+dMgtxKV8RQ/JvtlFcdZ1zCPA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.24.2':
+    resolution: {integrity: sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
@@ -1360,6 +1492,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.24.2':
+    resolution: {integrity: sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.17.19':
     resolution: {integrity: sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==}
     engines: {node: '>=12'}
@@ -1378,6 +1516,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.24.2':
+    resolution: {integrity: sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.17.19':
     resolution: {integrity: sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==}
     engines: {node: '>=12'}
@@ -1392,6 +1536,12 @@ packages:
 
   '@esbuild/win32-x64@0.24.0':
     resolution: {integrity: sha512-7IAFPrjSQIJrGsK6flwg7NFmwBoSTyF3rl7If0hNUFQU4ilTsEPL6GuMuU9BfIWVVGuRnuIidkSMC+c0Otu8IA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.24.2':
+    resolution: {integrity: sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1698,20 +1848,26 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@shikijs/core@1.24.3':
-    resolution: {integrity: sha512-VRcf4GYUIkxIchGM9DrapRcxtgojg4IWKUtX5EtW+4PJiGzF2xQqZSv27PJt+WLc18KT3CNLpNWow9JYV5n+Rg==}
+  '@shikijs/core@1.24.4':
+    resolution: {integrity: sha512-jjLsld+xEEGYlxAXDyGwWsKJ1sw5Pc1pnp4ai2ORpjx2UX08YYTC0NNqQYO1PaghYaR+PvgMOGuvzw2he9sk0Q==}
 
-  '@shikijs/engine-javascript@1.24.3':
-    resolution: {integrity: sha512-De8tNLvYjeK6V0Gb47jIH2M+OKkw+lWnSV1j3HVDFMlNIglmVcTMG2fASc29W0zuFbfEEwKjO8Fe4KYSO6Ce3w==}
+  '@shikijs/engine-javascript@1.24.4':
+    resolution: {integrity: sha512-TClaQOLvo9WEMJv6GoUsykQ6QdynuKszuORFWCke8qvi6PeLm7FcD9+7y45UenysxEWYpDL5KJaVXTngTE+2BA==}
 
   '@shikijs/engine-oniguruma@1.24.3':
     resolution: {integrity: sha512-iNnx950gs/5Nk+zrp1LuF+S+L7SKEhn8k9eXgFYPGhVshKppsYwRmW8tpmAMvILIMSDfrgqZ0w+3xWVQB//1Xw==}
 
-  '@shikijs/twoslash@1.24.3':
-    resolution: {integrity: sha512-BlspJvcWJCz8tda7RP55eBi2TIzPn9T5wR3NVR0LdX7Itf8YcmOmj0Do1p/s5DdKFgCarzFG+wY+MT1nYk7new==}
+  '@shikijs/engine-oniguruma@1.24.4':
+    resolution: {integrity: sha512-Do2ry6flp2HWdvpj2XOwwa0ljZBRy15HKZITzPcNIBOGSeprnA8gOooA/bLsSPuy8aJBa+Q/r34dMmC3KNL/zw==}
+
+  '@shikijs/twoslash@1.24.4':
+    resolution: {integrity: sha512-oCQhpbWK5/LsfPKeKzXwcZKVTkdawpCmMrCMDBZ4jjI/kiMiPIqDX9aC7ktLJaSO4/4XrcYzza4rTkQv39VCdw==}
 
   '@shikijs/types@1.24.3':
     resolution: {integrity: sha512-FPMrJ69MNxhRtldRk69CghvaGlbbN3pKRuvko0zvbfa2dXp4pAngByToqS5OY5jvN8D7LKR4RJE8UvzlCOuViw==}
+
+  '@shikijs/types@1.24.4':
+    resolution: {integrity: sha512-0r0XU7Eaow0PuDxuWC1bVqmWCgm3XqizIaT7SM42K03vc69LGooT0U8ccSR44xP/hGlNx4FKhtYpV+BU6aaKAA==}
 
   '@shikijs/vscode-textmate@9.3.1':
     resolution: {integrity: sha512-79QfK1393x9Ho60QFyLti+QfdJzRQCVLFb97kOIV7Eo9vQU/roINgk7m24uv0a7AUvN//RDH36FLjjK48v0s9g==}
@@ -1729,8 +1885,8 @@ packages:
       '@sveltejs/kit': ^2.0.0
       wrangler: ^3.28.4
 
-  '@sveltejs/kit@2.13.0':
-    resolution: {integrity: sha512-6t6ne00vZx/TjD6s0Jvwt8wRLKBwbSAN1nhlOzcLUSTYX1hTp4eCBaTPB5Yz/lu+tYcvz4YPEEuPv3yfsNp2gw==}
+  '@sveltejs/kit@2.14.0':
+    resolution: {integrity: sha512-lqLmFb9WTegpj+83cTzvXL6S19UuSf8LEhF/8Mmjg53qqLVMmJt4RcrzOZTzK+o8lgpuXTPYPyKB+RUTNd9JjQ==}
     engines: {node: '>=18.13'}
     hasBin: true
     peerDependencies:
@@ -2580,8 +2736,8 @@ packages:
   error-stack-parser-es@0.1.5:
     resolution: {integrity: sha512-xHku1X40RO+fO8yJ8Wh2f2rZWVjqyhb1zgq1yZ8aZRQkv6OOKhKWRUaht3eSCUbAOBaKIgM+ykwFLE+QUxgGeg==}
 
-  es-abstract@1.23.6:
-    resolution: {integrity: sha512-Ifco6n3yj2tMZDWNLyloZrytt9lqqlwvS83P3HtaETR0NUOYnIULGGHpktqYGObGy+8wc1okO25p8TjemhImvA==}
+  es-abstract@1.23.7:
+    resolution: {integrity: sha512-OygGC8kIcDhXX+6yAZRGLqwi2CmEXCbLQixeGUgYeR+Qwlppqmo7DIDr8XibtEBZp+fJcoYpoatp5qwLMEdcqQ==}
     engines: {node: '>= 0.4'}
 
   es-define-property@1.0.1:
@@ -2619,6 +2775,11 @@ packages:
 
   esbuild@0.24.0:
     resolution: {integrity: sha512-FuLPevChGDshgSicjisSooU0cemp/sGXR841D5LHMB7mTVOmsEHcAxaH3irL53+8YDIeVNQEySh4DaYU/iuPqQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.24.2:
+    resolution: {integrity: sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3077,8 +3238,8 @@ packages:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
 
-  is-core-module@2.16.0:
-    resolution: {integrity: sha512-urTSINYfAYgcbLb0yDQ6egFm6h3Mo1DcF9EkyXSRjjzdHbsulg01qhwWuXdOoUBuTkbQ80KDboXa0vFJ+BDH+g==}
+  is-core-module@2.16.1:
+    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
 
   is-data-view@1.0.2:
@@ -3136,10 +3297,6 @@ packages:
 
   is-module@1.0.0:
     resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
-
-  is-negative-zero@2.0.3:
-    resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
-    engines: {node: '>= 0.4'}
 
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
@@ -3728,8 +3885,8 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
-  oniguruma-to-es@0.8.0:
-    resolution: {integrity: sha512-rY+/a6b+uCgoYIL9itjY0x99UUDHXmGaw7Jjk5ZvM/3cxDJifyxFr/Zm4tTmF6Tre18gAakJo7AzhKUeMNLgHA==}
+  oniguruma-to-es@0.8.1:
+    resolution: {integrity: sha512-dekySTEvCxCj0IgKcA2uUCO/e4ArsqpucDPcX26w9ajx+DvMWLc5eZeJaRQkd7oC/+rwif5gnT900tA34uN9Zw==}
 
   open@10.1.0:
     resolution: {integrity: sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==}
@@ -3779,6 +3936,9 @@ packages:
 
   package-manager-detector@0.2.7:
     resolution: {integrity: sha512-g4+387DXDKlZzHkP+9FLt8yKj8+/3tOkPv7DVTJGGRm00RkEWgqbFstX1mXJ4M0VDYhUqsTOiISqNOJnhAu3PQ==}
+
+  package-manager-detector@0.2.8:
+    resolution: {integrity: sha512-ts9KSdroZisdvKMWVAVCXiKqnqNfXz4+IbrBG8/BWx/TR5le+jfenvoBuIZ6UWM9nz47W7AbD9qYfAwfWMIwzA==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -4194,8 +4354,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shiki@1.24.3:
-    resolution: {integrity: sha512-eMeX/ehE2IDKVs71kB4zVcDHjutNcOtm+yIRuR4sA6ThBbdFI0DffGJiyoKCodj0xRGxIoWC3pk/Anmm5mzHmA==}
+  shiki@1.24.4:
+    resolution: {integrity: sha512-aVGSFAOAr1v26Hh/+GBIsRVDWJ583XYV7CuNURKRWh9gpGv4OdbisZGq96B9arMYTZhTQkmRF5BrShOSTvNqhw==}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -5106,7 +5266,7 @@ snapshots:
 
   '@antfu/install-pkg@0.4.1':
     dependencies:
-      package-manager-detector: 0.2.7
+      package-manager-detector: 0.2.8
       tinyexec: 0.3.1
 
   '@antfu/utils@0.7.10': {}
@@ -6013,6 +6173,9 @@ snapshots:
   '@esbuild/aix-ppc64@0.24.0':
     optional: true
 
+  '@esbuild/aix-ppc64@0.24.2':
+    optional: true
+
   '@esbuild/android-arm64@0.17.19':
     optional: true
 
@@ -6020,6 +6183,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.24.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.24.2':
     optional: true
 
   '@esbuild/android-arm@0.17.19':
@@ -6031,6 +6197,9 @@ snapshots:
   '@esbuild/android-arm@0.24.0':
     optional: true
 
+  '@esbuild/android-arm@0.24.2':
+    optional: true
+
   '@esbuild/android-x64@0.17.19':
     optional: true
 
@@ -6038,6 +6207,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.24.0':
+    optional: true
+
+  '@esbuild/android-x64@0.24.2':
     optional: true
 
   '@esbuild/darwin-arm64@0.17.19':
@@ -6049,6 +6221,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.24.0':
     optional: true
 
+  '@esbuild/darwin-arm64@0.24.2':
+    optional: true
+
   '@esbuild/darwin-x64@0.17.19':
     optional: true
 
@@ -6056,6 +6231,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.24.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.24.2':
     optional: true
 
   '@esbuild/freebsd-arm64@0.17.19':
@@ -6067,6 +6245,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.24.0':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.24.2':
+    optional: true
+
   '@esbuild/freebsd-x64@0.17.19':
     optional: true
 
@@ -6074,6 +6255,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.24.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.24.2':
     optional: true
 
   '@esbuild/linux-arm64@0.17.19':
@@ -6085,6 +6269,9 @@ snapshots:
   '@esbuild/linux-arm64@0.24.0':
     optional: true
 
+  '@esbuild/linux-arm64@0.24.2':
+    optional: true
+
   '@esbuild/linux-arm@0.17.19':
     optional: true
 
@@ -6092,6 +6279,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.24.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.24.2':
     optional: true
 
   '@esbuild/linux-ia32@0.17.19':
@@ -6103,6 +6293,9 @@ snapshots:
   '@esbuild/linux-ia32@0.24.0':
     optional: true
 
+  '@esbuild/linux-ia32@0.24.2':
+    optional: true
+
   '@esbuild/linux-loong64@0.17.19':
     optional: true
 
@@ -6110,6 +6303,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.24.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.24.2':
     optional: true
 
   '@esbuild/linux-mips64el@0.17.19':
@@ -6121,6 +6317,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.24.0':
     optional: true
 
+  '@esbuild/linux-mips64el@0.24.2':
+    optional: true
+
   '@esbuild/linux-ppc64@0.17.19':
     optional: true
 
@@ -6128,6 +6327,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.24.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.24.2':
     optional: true
 
   '@esbuild/linux-riscv64@0.17.19':
@@ -6139,6 +6341,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.24.0':
     optional: true
 
+  '@esbuild/linux-riscv64@0.24.2':
+    optional: true
+
   '@esbuild/linux-s390x@0.17.19':
     optional: true
 
@@ -6146,6 +6351,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.24.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.24.2':
     optional: true
 
   '@esbuild/linux-x64@0.17.19':
@@ -6157,6 +6365,12 @@ snapshots:
   '@esbuild/linux-x64@0.24.0':
     optional: true
 
+  '@esbuild/linux-x64@0.24.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.24.2':
+    optional: true
+
   '@esbuild/netbsd-x64@0.17.19':
     optional: true
 
@@ -6166,10 +6380,16 @@ snapshots:
   '@esbuild/netbsd-x64@0.24.0':
     optional: true
 
+  '@esbuild/netbsd-x64@0.24.2':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.23.1':
     optional: true
 
   '@esbuild/openbsd-arm64@0.24.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.24.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.17.19':
@@ -6181,6 +6401,9 @@ snapshots:
   '@esbuild/openbsd-x64@0.24.0':
     optional: true
 
+  '@esbuild/openbsd-x64@0.24.2':
+    optional: true
+
   '@esbuild/sunos-x64@0.17.19':
     optional: true
 
@@ -6188,6 +6411,9 @@ snapshots:
     optional: true
 
   '@esbuild/sunos-x64@0.24.0':
+    optional: true
+
+  '@esbuild/sunos-x64@0.24.2':
     optional: true
 
   '@esbuild/win32-arm64@0.17.19':
@@ -6199,6 +6425,9 @@ snapshots:
   '@esbuild/win32-arm64@0.24.0':
     optional: true
 
+  '@esbuild/win32-arm64@0.24.2':
+    optional: true
+
   '@esbuild/win32-ia32@0.17.19':
     optional: true
 
@@ -6208,6 +6437,9 @@ snapshots:
   '@esbuild/win32-ia32@0.24.0':
     optional: true
 
+  '@esbuild/win32-ia32@0.24.2':
+    optional: true
+
   '@esbuild/win32-x64@0.17.19':
     optional: true
 
@@ -6215,6 +6447,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.24.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.24.2':
     optional: true
 
   '@eslint-community/eslint-utils@4.4.1(eslint@9.17.0(jiti@1.21.7))':
@@ -6496,36 +6731,46 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.28.1':
     optional: true
 
-  '@shikijs/core@1.24.3':
+  '@shikijs/core@1.24.4':
     dependencies:
-      '@shikijs/engine-javascript': 1.24.3
-      '@shikijs/engine-oniguruma': 1.24.3
-      '@shikijs/types': 1.24.3
+      '@shikijs/engine-javascript': 1.24.4
+      '@shikijs/engine-oniguruma': 1.24.4
+      '@shikijs/types': 1.24.4
       '@shikijs/vscode-textmate': 9.3.1
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.4
 
-  '@shikijs/engine-javascript@1.24.3':
+  '@shikijs/engine-javascript@1.24.4':
     dependencies:
-      '@shikijs/types': 1.24.3
+      '@shikijs/types': 1.24.4
       '@shikijs/vscode-textmate': 9.3.1
-      oniguruma-to-es: 0.8.0
+      oniguruma-to-es: 0.8.1
 
   '@shikijs/engine-oniguruma@1.24.3':
     dependencies:
       '@shikijs/types': 1.24.3
       '@shikijs/vscode-textmate': 9.3.1
 
-  '@shikijs/twoslash@1.24.3(typescript@5.7.2)':
+  '@shikijs/engine-oniguruma@1.24.4':
     dependencies:
-      '@shikijs/core': 1.24.3
-      '@shikijs/types': 1.24.3
+      '@shikijs/types': 1.24.4
+      '@shikijs/vscode-textmate': 9.3.1
+
+  '@shikijs/twoslash@1.24.4(typescript@5.7.2)':
+    dependencies:
+      '@shikijs/core': 1.24.4
+      '@shikijs/types': 1.24.4
       twoslash: 0.2.12(typescript@5.7.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
   '@shikijs/types@1.24.3':
+    dependencies:
+      '@shikijs/vscode-textmate': 9.3.1
+      '@types/hast': 3.0.4
+
+  '@shikijs/types@1.24.4':
     dependencies:
       '@shikijs/vscode-textmate': 9.3.1
       '@types/hast': 3.0.4
@@ -6541,15 +6786,15 @@ snapshots:
       magic-string: 0.25.9
       string.prototype.matchall: 4.0.12
 
-  '@sveltejs/adapter-cloudflare@4.9.0(@sveltejs/kit@2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(wrangler@3.96.0(@cloudflare/workers-types@4.20241218.0))':
+  '@sveltejs/adapter-cloudflare@4.9.0(@sveltejs/kit@2.14.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(wrangler@3.96.0(@cloudflare/workers-types@4.20241218.0))':
     dependencies:
       '@cloudflare/workers-types': 4.20241218.0
-      '@sveltejs/kit': 2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
-      esbuild: 0.24.0
+      '@sveltejs/kit': 2.14.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
+      esbuild: 0.24.2
       worktop: 0.8.0-next.18
       wrangler: 3.96.0(@cloudflare/workers-types@4.20241218.0)
 
-  '@sveltejs/kit@2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))':
+  '@sveltejs/kit@2.14.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
       '@types/cookie': 0.6.0
@@ -6589,21 +6834,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltepress/theme-default@5.0.5(rbgpjl43s7mzugr5hgnsgubuf4)':
+  '@sveltepress/theme-default@5.0.5(rwjuugdagobrixgkl2o7udorhm)':
     dependencies:
       '@docsearch/css': 3.8.2
       '@docsearch/js': 3.8.2(@algolia/client-search@5.18.0)(search-insights@2.17.3)
-      '@shikijs/twoslash': 1.24.3(typescript@5.7.2)
-      '@sveltejs/kit': 2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
+      '@shikijs/twoslash': 1.24.4(typescript@5.7.2)
+      '@sveltejs/kit': 2.14.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
       '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
       '@sveltepress/twoslash': 1.1.5(svelte@5.14.4)(typescript@5.7.2)
-      '@sveltepress/vite': 1.1.2(@sveltejs/kit@2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(rollup@2.79.2)(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
+      '@sveltepress/vite': 1.1.2(@sveltejs/kit@2.14.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(rollup@2.79.2)(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
       '@unocss/extractor-svelte': 0.61.9
-      '@vite-pwa/sveltekit': 0.6.6(@sveltejs/kit@2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(vite-plugin-pwa@0.21.1(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))(workbox-build@7.3.0)(workbox-window@7.3.0))
+      '@vite-pwa/sveltekit': 0.6.6(@sveltejs/kit@2.14.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(vite-plugin-pwa@0.21.1(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))(workbox-build@7.3.0)(workbox-window@7.3.0))
       lru-cache: 10.4.3
       mdast-util-from-markdown: 2.0.2
       mdast-util-gfm: 3.0.0
-      shiki: 1.24.3
+      shiki: 1.24.4
       svelte: 5.14.4
       uid: 2.0.2
       unist-util-visit: 5.0.0
@@ -6628,11 +6873,11 @@ snapshots:
   '@sveltepress/twoslash@1.1.5(svelte@5.14.4)(typescript@5.7.2)':
     dependencies:
       '@floating-ui/dom': 1.6.12
-      '@shikijs/twoslash': 1.24.3(typescript@5.7.2)
+      '@shikijs/twoslash': 1.24.4(typescript@5.7.2)
       mdast-util-from-markdown: 2.0.2
       mdast-util-gfm: 3.0.0
       mdast-util-to-hast: 13.2.0
-      shiki: 1.24.3
+      shiki: 1.24.4
       source-map-js: 1.2.1
       svelte: 5.14.4
       svelte2tsx: 0.7.31(svelte@5.14.4)(typescript@5.7.2)
@@ -6642,9 +6887,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@sveltepress/vite@1.1.2(@sveltejs/kit@2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(rollup@2.79.2)(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))':
+  '@sveltepress/vite@1.1.2(@sveltejs/kit@2.14.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(rollup@2.79.2)(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))':
     dependencies:
-      '@sveltejs/kit': 2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
+      '@sveltejs/kit': 2.14.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
       '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
       cross-spawn: 7.0.6
       fs-extra: 11.2.0
@@ -6659,7 +6904,7 @@ snapshots:
       remark-parse: 11.0.0
       remark-rehype: 11.1.1
       remark-stringify: 11.0.0
-      shiki: 1.24.3
+      shiki: 1.24.4
       svelte: 5.14.4
       unified: 11.0.5
       unist-util-visit: 5.0.0
@@ -6978,9 +7223,9 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vite-pwa/sveltekit@0.6.6(@sveltejs/kit@2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(vite-plugin-pwa@0.21.1(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))(workbox-build@7.3.0)(workbox-window@7.3.0))':
+  '@vite-pwa/sveltekit@0.6.6(@sveltejs/kit@2.14.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(vite-plugin-pwa@0.21.1(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))(workbox-build@7.3.0)(workbox-window@7.3.0))':
     dependencies:
-      '@sveltejs/kit': 2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
+      '@sveltejs/kit': 2.14.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
       kolorist: 1.8.0
       tinyglobby: 0.2.10
       vite-plugin-pwa: 0.21.1(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))(workbox-build@7.3.0)(workbox-window@7.3.0)
@@ -7178,7 +7423,7 @@ snapshots:
       array-buffer-byte-length: 1.0.2
       call-bind: 1.0.8
       define-properties: 1.2.1
-      es-abstract: 1.23.6
+      es-abstract: 1.23.7
       es-errors: 1.3.0
       get-intrinsic: 1.2.6
       is-array-buffer: 3.0.5
@@ -7603,7 +7848,7 @@ snapshots:
 
   error-stack-parser-es@0.1.5: {}
 
-  es-abstract@1.23.6:
+  es-abstract@1.23.7:
     dependencies:
       array-buffer-byte-length: 1.0.2
       arraybuffer.prototype.slice: 1.0.4
@@ -7631,7 +7876,6 @@ snapshots:
       is-array-buffer: 3.0.5
       is-callable: 1.2.7
       is-data-view: 1.0.2
-      is-negative-zero: 2.0.3
       is-regex: 1.2.1
       is-shared-array-buffer: 1.0.4
       is-string: 1.1.1
@@ -7754,6 +7998,34 @@ snapshots:
       '@esbuild/win32-arm64': 0.24.0
       '@esbuild/win32-ia32': 0.24.0
       '@esbuild/win32-x64': 0.24.0
+
+  esbuild@0.24.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.24.2
+      '@esbuild/android-arm': 0.24.2
+      '@esbuild/android-arm64': 0.24.2
+      '@esbuild/android-x64': 0.24.2
+      '@esbuild/darwin-arm64': 0.24.2
+      '@esbuild/darwin-x64': 0.24.2
+      '@esbuild/freebsd-arm64': 0.24.2
+      '@esbuild/freebsd-x64': 0.24.2
+      '@esbuild/linux-arm': 0.24.2
+      '@esbuild/linux-arm64': 0.24.2
+      '@esbuild/linux-ia32': 0.24.2
+      '@esbuild/linux-loong64': 0.24.2
+      '@esbuild/linux-mips64el': 0.24.2
+      '@esbuild/linux-ppc64': 0.24.2
+      '@esbuild/linux-riscv64': 0.24.2
+      '@esbuild/linux-s390x': 0.24.2
+      '@esbuild/linux-x64': 0.24.2
+      '@esbuild/netbsd-arm64': 0.24.2
+      '@esbuild/netbsd-x64': 0.24.2
+      '@esbuild/openbsd-arm64': 0.24.2
+      '@esbuild/openbsd-x64': 0.24.2
+      '@esbuild/sunos-x64': 0.24.2
+      '@esbuild/win32-arm64': 0.24.2
+      '@esbuild/win32-ia32': 0.24.2
+      '@esbuild/win32-x64': 0.24.2
 
   escalade@3.2.0: {}
 
@@ -8273,7 +8545,7 @@ snapshots:
 
   is-callable@1.2.7: {}
 
-  is-core-module@2.16.0:
+  is-core-module@2.16.1:
     dependencies:
       hasown: 2.0.2
 
@@ -8319,8 +8591,6 @@ snapshots:
   is-map@2.0.3: {}
 
   is-module@1.0.0: {}
-
-  is-negative-zero@2.0.3: {}
 
   is-number-object@1.1.1:
     dependencies:
@@ -9080,7 +9350,7 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  oniguruma-to-es@0.8.0:
+  oniguruma-to-es@0.8.1:
     dependencies:
       emoji-regex-xs: 1.0.0
       regex: 5.0.2
@@ -9133,6 +9403,8 @@ snapshots:
   package-json-from-dist@1.0.1: {}
 
   package-manager-detector@0.2.7: {}
+
+  package-manager-detector@0.2.8: {}
 
   parent-module@1.0.1:
     dependencies:
@@ -9286,7 +9558,7 @@ snapshots:
       call-bind: 1.0.8
       define-properties: 1.2.1
       dunder-proto: 1.0.1
-      es-abstract: 1.23.6
+      es-abstract: 1.23.7
       es-errors: 1.3.0
       get-intrinsic: 1.2.6
       gopd: 1.2.0
@@ -9429,7 +9701,7 @@ snapshots:
 
   resolve@1.22.10:
     dependencies:
-      is-core-module: 2.16.0
+      is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
@@ -9591,12 +9863,12 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shiki@1.24.3:
+  shiki@1.24.4:
     dependencies:
-      '@shikijs/core': 1.24.3
-      '@shikijs/engine-javascript': 1.24.3
-      '@shikijs/engine-oniguruma': 1.24.3
-      '@shikijs/types': 1.24.3
+      '@shikijs/core': 1.24.4
+      '@shikijs/engine-javascript': 1.24.4
+      '@shikijs/engine-oniguruma': 1.24.4
+      '@shikijs/types': 1.24.4
       '@shikijs/vscode-textmate': 9.3.1
       '@types/hast': 3.0.4
 
@@ -9706,7 +9978,7 @@ snapshots:
       call-bind: 1.0.8
       call-bound: 1.0.3
       define-properties: 1.2.1
-      es-abstract: 1.23.6
+      es-abstract: 1.23.7
       es-errors: 1.3.0
       es-object-atoms: 1.0.0
       get-intrinsic: 1.2.6
@@ -9723,7 +9995,7 @@ snapshots:
       call-bound: 1.0.3
       define-data-property: 1.1.4
       define-properties: 1.2.1
-      es-abstract: 1.23.6
+      es-abstract: 1.23.7
       es-object-atoms: 1.0.0
       has-property-descriptors: 1.0.2
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,8 +127,8 @@ importers:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.49)
       runed:
-        specifier: ^0.21.0
-        version: 0.21.0(svelte@5.14.4)
+        specifier: ^0.22.0
+        version: 0.22.0(svelte@5.14.4)
       svelte:
         specifier: 'catalog:'
         version: 5.14.4
@@ -148,8 +148,8 @@ importers:
         specifier: 'catalog:'
         version: 5.14.4
       svelte2tsx:
-        specifier: ^0.7.26
-        version: 0.7.30(svelte@5.14.4)(typescript@5.7.2)
+        specifier: ^0.7.31
+        version: 0.7.31(svelte@5.14.4)(typescript@5.7.2)
       typescript:
         specifier: 'catalog:'
         version: 5.7.2
@@ -170,7 +170,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1(hono@4.6.14)(valibot@1.0.0-beta.9(typescript@5.7.2))
       hono:
-        specifier: ^4.6.13
+        specifier: ^4.6.14
         version: 4.6.14
       svelte-docgen:
         specifier: workspace:*
@@ -4275,8 +4275,8 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
-  runed@0.21.0:
-    resolution: {integrity: sha512-jqegxzCmUMrt11hGunWNVs9QVNJqOzqpC1a/UlPpDzHQ0YlSlsNhkfyt12bSaHlwHRdHcr7ZVxCxKVhWOVLcmw==}
+  runed@0.22.0:
+    resolution: {integrity: sha512-ZWVXWhOr0P5xdNgtviz6D1ivLUDWKLCbeC5SUEJ3zBkqLReVqWHenFxMNFeFaiC5bfxhFxyxzyzB+98uYFtwdA==}
     peerDependencies:
       svelte: ^5.7.0
 
@@ -4526,12 +4526,6 @@ packages:
     peerDependenciesMeta:
       svelte:
         optional: true
-
-  svelte2tsx@0.7.30:
-    resolution: {integrity: sha512-sHXK/vw/sVJmFuPSq6zeKrtuZKvo0jJyEi8ybN0dfrqSYVvHu8zFbO0zQKAL8y/fYackYojH41EJGe6v8rd5fw==}
-    peerDependencies:
-      svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
-      typescript: ^4.9.4 || ^5.0.0
 
   svelte2tsx@0.7.31:
     resolution: {integrity: sha512-exrN1o9mdCLAA7hTCudz731FIxomH/0SN9ZIX+WrY/XnlLuno/NNC1PF6JXPZVqp/4sMMDKteqyKoG44hliljQ==}
@@ -9763,7 +9757,7 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  runed@0.21.0(svelte@5.14.4):
+  runed@0.22.0(svelte@5.14.4):
     dependencies:
       esm-env: 1.2.1
       svelte: 5.14.4
@@ -10068,13 +10062,6 @@ snapshots:
       postcss-scss: 4.0.9(postcss@8.4.49)
     optionalDependencies:
       svelte: 5.14.4
-
-  svelte2tsx@0.7.30(svelte@5.14.4)(typescript@5.7.2):
-    dependencies:
-      dedent-js: 1.0.1
-      pascal-case: 3.1.2
-      svelte: 5.14.4
-      typescript: 5.7.2
 
   svelte2tsx@0.7.31(svelte@5.14.4)(typescript@5.7.2):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,7 +112,7 @@ importers:
         specifier: ^2.14.0
         version: 2.14.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
       '@sveltejs/vite-plugin-svelte':
-        specifier: ^5.0.3
+        specifier: ^5.0.0
         version: 5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
       '@sveltepress/theme-default':
         specifier: ^5.0.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,7 +201,7 @@ importers:
         specifier: 'catalog:'
         version: 5.14.4
       typescript:
-        specifier: 'catalog:'
+        specifier: ^5.0.0
         version: 5.7.2
       valibot:
         specifier: 'catalog:'
@@ -1854,17 +1854,11 @@ packages:
   '@shikijs/engine-javascript@1.24.4':
     resolution: {integrity: sha512-TClaQOLvo9WEMJv6GoUsykQ6QdynuKszuORFWCke8qvi6PeLm7FcD9+7y45UenysxEWYpDL5KJaVXTngTE+2BA==}
 
-  '@shikijs/engine-oniguruma@1.24.3':
-    resolution: {integrity: sha512-iNnx950gs/5Nk+zrp1LuF+S+L7SKEhn8k9eXgFYPGhVshKppsYwRmW8tpmAMvILIMSDfrgqZ0w+3xWVQB//1Xw==}
-
   '@shikijs/engine-oniguruma@1.24.4':
     resolution: {integrity: sha512-Do2ry6flp2HWdvpj2XOwwa0ljZBRy15HKZITzPcNIBOGSeprnA8gOooA/bLsSPuy8aJBa+Q/r34dMmC3KNL/zw==}
 
   '@shikijs/twoslash@1.24.4':
     resolution: {integrity: sha512-oCQhpbWK5/LsfPKeKzXwcZKVTkdawpCmMrCMDBZ4jjI/kiMiPIqDX9aC7ktLJaSO4/4XrcYzza4rTkQv39VCdw==}
-
-  '@shikijs/types@1.24.3':
-    resolution: {integrity: sha512-FPMrJ69MNxhRtldRk69CghvaGlbbN3pKRuvko0zvbfa2dXp4pAngByToqS5OY5jvN8D7LKR4RJE8UvzlCOuViw==}
 
   '@shikijs/types@1.24.4':
     resolution: {integrity: sha512-0r0XU7Eaow0PuDxuWC1bVqmWCgm3XqizIaT7SM42K03vc69LGooT0U8ccSR44xP/hGlNx4FKhtYpV+BU6aaKAA==}
@@ -3933,9 +3927,6 @@ packages:
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
-
-  package-manager-detector@0.2.7:
-    resolution: {integrity: sha512-g4+387DXDKlZzHkP+9FLt8yKj8+/3tOkPv7DVTJGGRm00RkEWgqbFstX1mXJ4M0VDYhUqsTOiISqNOJnhAu3PQ==}
 
   package-manager-detector@0.2.8:
     resolution: {integrity: sha512-ts9KSdroZisdvKMWVAVCXiKqnqNfXz4+IbrBG8/BWx/TR5le+jfenvoBuIZ6UWM9nz47W7AbD9qYfAwfWMIwzA==}
@@ -6006,7 +5997,7 @@ snapshots:
       fs-extra: 7.0.1
       mri: 1.2.0
       p-limit: 2.3.0
-      package-manager-detector: 0.2.7
+      package-manager-detector: 0.2.8
       picocolors: 1.1.1
       resolve-from: 5.0.0
       semver: 7.6.3
@@ -6506,8 +6497,8 @@ snapshots:
 
   '@gerrit0/mini-shiki@1.24.4':
     dependencies:
-      '@shikijs/engine-oniguruma': 1.24.3
-      '@shikijs/types': 1.24.3
+      '@shikijs/engine-oniguruma': 1.24.4
+      '@shikijs/types': 1.24.4
       '@shikijs/vscode-textmate': 9.3.1
 
   '@hono/node-server@1.13.7(hono@4.6.14)':
@@ -6740,11 +6731,6 @@ snapshots:
       '@shikijs/vscode-textmate': 9.3.1
       oniguruma-to-es: 0.8.1
 
-  '@shikijs/engine-oniguruma@1.24.3':
-    dependencies:
-      '@shikijs/types': 1.24.3
-      '@shikijs/vscode-textmate': 9.3.1
-
   '@shikijs/engine-oniguruma@1.24.4':
     dependencies:
       '@shikijs/types': 1.24.4
@@ -6758,11 +6744,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
-
-  '@shikijs/types@1.24.3':
-    dependencies:
-      '@shikijs/vscode-textmate': 9.3.1
-      '@types/hast': 3.0.4
 
   '@shikijs/types@1.24.4':
     dependencies:
@@ -9395,8 +9376,6 @@ snapshots:
   p-try@2.2.0: {}
 
   package-json-from-dist@1.0.1: {}
-
-  package-manager-detector@0.2.7: {}
 
   package-manager-detector@0.2.8: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ catalogs:
       version: 1.0.0-beta.9
 
 overrides:
-  vite: ^6.0.0
+  vite: ^6.0.5
   '@sveltejs/vite-plugin-svelte': ^5.0.0
 
 importers:
@@ -60,6 +60,9 @@ importers:
       globals:
         specifier: ^15.14.0
         version: 15.14.0
+      pathe:
+        specifier: ^1.1.2
+        version: 1.1.2
       prettier:
         specifier: ^3.4.2
         version: 3.4.2
@@ -94,8 +97,8 @@ importers:
         specifier: ^8.18.1
         version: 8.18.1(eslint@9.17.0(jiti@1.21.7))(typescript@5.7.2)
       vite:
-        specifier: ^6.0.0
-        version: 6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
+        specifier: ^6.0.5
+        version: 6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
       vitest:
         specifier: 2.1.8
         version: 2.1.8(@types/node@22.10.2)(@vitest/ui@2.1.8)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
@@ -103,26 +106,38 @@ importers:
   apps/docs:
     devDependencies:
       '@sveltejs/adapter-cloudflare':
-        specifier: ^4.8.0
-        version: 4.8.0(@sveltejs/kit@2.12.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(wrangler@3.96.0(@cloudflare/workers-types@4.20241218.0))
+        specifier: ^4.9.0
+        version: 4.9.0(@sveltejs/kit@2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(wrangler@3.96.0(@cloudflare/workers-types@4.20241218.0))
       '@sveltejs/kit':
-        specifier: ^2.12.1
-        version: 2.12.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
+        specifier: ^2.13.0
+        version: 2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.0
-        version: 5.0.3(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
+        version: 5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
       '@sveltepress/theme-default':
         specifier: ^5.0.5
-        version: 5.0.5(q55a3n3uh4nvx5danag6r6gtau)
+        version: 5.0.5(rbgpjl43s7mzugr5hgnsgubuf4)
       '@sveltepress/vite':
         specifier: ^1.1.2
-        version: 1.1.2(@sveltejs/kit@2.12.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(rollup@2.79.2)(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
+        version: 1.1.2(@sveltejs/kit@2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(rollup@2.79.2)(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
+      '@typescript/vfs':
+        specifier: ^1.6.0
+        version: 1.6.0(typescript@5.7.2)
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.49)
+      runed:
+        specifier: ^0.21.0
+        version: 0.21.0(svelte@5.14.4)
       svelte:
         specifier: 'catalog:'
         version: 5.14.4
+      svelte-docgen:
+        specifier: workspace:*
+        version: link:../../packages/svelte-docgen
+      svelte2tsx:
+        specifier: ^0.7.31
+        version: 0.7.31(svelte@5.14.4)(typescript@5.7.2)
 
   packages/extractor:
     dependencies:
@@ -211,8 +226,8 @@ importers:
         specifier: 'catalog:'
         version: 5.7.2
       vite:
-        specifier: ^6.0.0
-        version: 6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
+        specifier: ^6.0.5
+        version: 6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
       zimmerframe:
         specifier: ^1.1.2
         version: 1.1.2
@@ -1683,20 +1698,20 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@shikijs/core@1.24.2':
-    resolution: {integrity: sha512-BpbNUSKIwbKrRRA+BQj0BEWSw+8kOPKDJevWeSE/xIqGX7K0xrCZQ9kK0nnEQyrzsUoka1l81ZtJ2mGaCA32HQ==}
+  '@shikijs/core@1.24.3':
+    resolution: {integrity: sha512-VRcf4GYUIkxIchGM9DrapRcxtgojg4IWKUtX5EtW+4PJiGzF2xQqZSv27PJt+WLc18KT3CNLpNWow9JYV5n+Rg==}
 
-  '@shikijs/engine-javascript@1.24.2':
-    resolution: {integrity: sha512-EqsmYBJdLEwEiO4H+oExz34a5GhhnVp+jH9Q/XjPjmBPc6TE/x4/gD0X3i0EbkKKNqXYHHJTJUpOLRQNkEzS9Q==}
+  '@shikijs/engine-javascript@1.24.3':
+    resolution: {integrity: sha512-De8tNLvYjeK6V0Gb47jIH2M+OKkw+lWnSV1j3HVDFMlNIglmVcTMG2fASc29W0zuFbfEEwKjO8Fe4KYSO6Ce3w==}
 
-  '@shikijs/engine-oniguruma@1.24.2':
-    resolution: {integrity: sha512-ZN6k//aDNWRJs1uKB12pturKHh7GejKugowOFGAuG7TxDRLod1Bd5JhpOikOiFqPmKjKEPtEA6mRCf7q3ulDyQ==}
+  '@shikijs/engine-oniguruma@1.24.3':
+    resolution: {integrity: sha512-iNnx950gs/5Nk+zrp1LuF+S+L7SKEhn8k9eXgFYPGhVshKppsYwRmW8tpmAMvILIMSDfrgqZ0w+3xWVQB//1Xw==}
 
-  '@shikijs/twoslash@1.24.2':
-    resolution: {integrity: sha512-zcwYUNdSQDKquF1t+XrtoXM+lx9rCldAkZnT+e5fULKlLT6F8/F9fwICGhBm9lWp5/U4NptH+YcJUdvFOR0SRg==}
+  '@shikijs/twoslash@1.24.3':
+    resolution: {integrity: sha512-BlspJvcWJCz8tda7RP55eBi2TIzPn9T5wR3NVR0LdX7Itf8YcmOmj0Do1p/s5DdKFgCarzFG+wY+MT1nYk7new==}
 
-  '@shikijs/types@1.24.2':
-    resolution: {integrity: sha512-bdeWZiDtajGLG9BudI0AHet0b6e7FbR0EsE4jpGaI0YwHm/XJunI9+3uZnzFtX65gsyJ6ngCIWUfA4NWRPnBkQ==}
+  '@shikijs/types@1.24.3':
+    resolution: {integrity: sha512-FPMrJ69MNxhRtldRk69CghvaGlbbN3pKRuvko0zvbfa2dXp4pAngByToqS5OY5jvN8D7LKR4RJE8UvzlCOuViw==}
 
   '@shikijs/vscode-textmate@9.3.1':
     resolution: {integrity: sha512-79QfK1393x9Ho60QFyLti+QfdJzRQCVLFb97kOIV7Eo9vQU/roINgk7m24uv0a7AUvN//RDH36FLjjK48v0s9g==}
@@ -1708,20 +1723,20 @@ packages:
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     resolution: {integrity: sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==}
 
-  '@sveltejs/adapter-cloudflare@4.8.0':
-    resolution: {integrity: sha512-stt72ZXDmRoLBqqj2fAdMXyOZ0vDUoAiNe/GRKkfxb1wW5Smp/jBGhKVBwhlAIi7aeE0xEMehN1SBxId9QMh5g==}
+  '@sveltejs/adapter-cloudflare@4.9.0':
+    resolution: {integrity: sha512-o7o8wXy5zDsEuE9oPWSHO5tAuPEulZZg2QavFdc00fcIHh1dxgCyIRZa5LPjAE8EcdJOh+8SFkhFgVRdCfOBvQ==}
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
       wrangler: ^3.28.4
 
-  '@sveltejs/kit@2.12.2':
-    resolution: {integrity: sha512-7/nHyKxo3wzBMownGgaVvEfM2TGLwjUKgmHhLw/Qbyb5xmJ+40vYa0V2XJqJ2fRnTCfCcJ0Ya51ZVNW3vtn4rA==}
+  '@sveltejs/kit@2.13.0':
+    resolution: {integrity: sha512-6t6ne00vZx/TjD6s0Jvwt8wRLKBwbSAN1nhlOzcLUSTYX1hTp4eCBaTPB5Yz/lu+tYcvz4YPEEuPv3yfsNp2gw==}
     engines: {node: '>=18.13'}
     hasBin: true
     peerDependencies:
       '@sveltejs/vite-plugin-svelte': ^5.0.0
       svelte: ^4.0.0 || ^5.0.0-next.0
-      vite: ^6.0.0
+      vite: ^6.0.5
 
   '@sveltejs/vite-plugin-svelte-inspector@4.0.1':
     resolution: {integrity: sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==}
@@ -1729,14 +1744,14 @@ packages:
     peerDependencies:
       '@sveltejs/vite-plugin-svelte': ^5.0.0
       svelte: ^5.0.0
-      vite: ^6.0.0
+      vite: ^6.0.5
 
   '@sveltejs/vite-plugin-svelte@5.0.3':
     resolution: {integrity: sha512-MCFS6CrQDu1yGwspm4qtli0e63vaPCehf6V7pIMP15AsWgMKrqDGCPFF/0kn4SP0ii4aySu4Pa62+fIRGFMjgw==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22}
     peerDependencies:
       svelte: ^5.0.0
-      vite: ^6.0.0
+      vite: ^6.0.5
 
   '@sveltepress/theme-default@5.0.5':
     resolution: {integrity: sha512-vV1a1qDo+PDKI0OR/Mce8QRJ89d3mpF1JXiqdreozRsQ+wHLeKe2HGFK6GwYZ2y7AVgVKXSl9pDyXbHGZDOZDA==}
@@ -1745,7 +1760,7 @@ packages:
       '@sveltejs/vite-plugin-svelte': ^5.0.0
       '@sveltepress/vite': 1.1.2
       svelte: ^5.0.0
-      vite: ^6.0.0
+      vite: ^6.0.5
 
   '@sveltepress/twoslash@1.1.5':
     resolution: {integrity: sha512-9uFJCLAlc/iGndqWjm9livltcrxGHcmZWlkg0fu6Rnzz8SOWzPvIFZknaDirzEyOA5aSORYbgEmMevCaYL5XCw==}
@@ -1758,7 +1773,7 @@ packages:
       '@sveltejs/kit': ^1.20.4 || ^2.0.0
       '@sveltejs/vite-plugin-svelte': ^5.0.0
       svelte: ^5.0.0
-      vite: ^6.0.0
+      vite: ^6.0.5
 
   '@types/bun@1.1.14':
     resolution: {integrity: sha512-opVYiFGtO2af0dnWBdZWlioLBoxSdDO5qokaazLhq8XQtGZbY4pY3/JxY8Zdf/hEwGubbp7ErZXoN1+h2yesxA==}
@@ -1878,7 +1893,7 @@ packages:
   '@unocss/astro@0.61.9':
     resolution: {integrity: sha512-adOXz4itYHxqhvQgJHlEU58EHDTtY2qrcEPVmQVk4qI1W+ezQV6nQMQvti8mS/HbFw3MOJhIY1MlJoZK36/cyw==}
     peerDependencies:
-      vite: ^6.0.0
+      vite: ^6.0.5
     peerDependenciesMeta:
       vite:
         optional: true
@@ -1962,7 +1977,7 @@ packages:
   '@unocss/vite@0.61.9':
     resolution: {integrity: sha512-hP/sL9rq1DvVCbSSx05m+bwYqen1nHm9tW6elKFkfV7X5jBUywu24WRq551NZI33KmgHA525ApX++DSWye+0uw==}
     peerDependencies:
-      vite: ^6.0.0
+      vite: ^6.0.5
 
   '@vite-pwa/sveltekit@0.6.6':
     resolution: {integrity: sha512-f08xlcfZyaXgytl05hUtCLih7Vr8zOk/E4eE/UK71M+sEGk+y+vUyTuR8td8KQalpf1Begb8XkxAkV7iUj2a0g==}
@@ -1991,7 +2006,7 @@ packages:
     resolution: {integrity: sha512-7guJ/47I6uqfttp33mgo6ga5Gr1VnL58rcqYKyShoRK9ebu8T5Rs6HN3s1NABiBeVTdWNrwUMcHH54uXZBN4zA==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0
+      vite: ^6.0.5
     peerDependenciesMeta:
       msw:
         optional: true
@@ -2109,8 +2124,8 @@ packages:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
 
-  array-buffer-byte-length@1.0.1:
-    resolution: {integrity: sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==}
+  array-buffer-byte-length@1.0.2:
+    resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
     engines: {node: '>= 0.4'}
 
   array-union@2.1.0:
@@ -2362,8 +2377,8 @@ packages:
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
-  consola@3.2.3:
-    resolution: {integrity: sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==}
+  consola@3.3.0:
+    resolution: {integrity: sha512-kxltocVQCwQNFvw40dlVRYeAkAvtYjMFZYNlOcsF5wExPpGwPxMwgx4IfDJvBRPtBpnQwItd5WkTaR0ZwT/TmQ==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
   content-disposition@0.5.2:
@@ -2404,16 +2419,16 @@ packages:
   data-uri-to-buffer@2.0.2:
     resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==}
 
-  data-view-buffer@1.0.1:
-    resolution: {integrity: sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==}
+  data-view-buffer@1.0.2:
+    resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
     engines: {node: '>= 0.4'}
 
-  data-view-byte-length@1.0.1:
-    resolution: {integrity: sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==}
+  data-view-byte-length@1.0.2:
+    resolution: {integrity: sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==}
     engines: {node: '>= 0.4'}
 
-  data-view-byte-offset@1.0.0:
-    resolution: {integrity: sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==}
+  data-view-byte-offset@1.0.1:
+    resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
   dataloader@1.4.0:
@@ -2536,8 +2551,8 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  electron-to-chromium@1.5.74:
-    resolution: {integrity: sha512-ck3//9RC+6oss/1Bh9tiAVFy5vfSKbRHAFh7Z3/eTRkEqJeWgymloShB17Vg3Z4nmDNp35vAd1BZ6CMW4Wt6Iw==}
+  electron-to-chromium@1.5.75:
+    resolution: {integrity: sha512-Lf3++DumRE/QmweGjU+ZcKqQ+3bKkU/qjaKYhIJKEOhgIO9Xs6IiAQFkfFoj+RhgDk4LUeNsLo6plExHqSyu6Q==}
 
   emoji-regex-xs@1.0.0:
     resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
@@ -2844,8 +2859,8 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
-  function.prototype.name@1.1.7:
-    resolution: {integrity: sha512-2g4x+HqTJKM9zcJqBSpjoRmdcPFtJM60J3xJisTQSXBWka5XqyBN/2tNUgma1mztTXyDuUsEtYe5qcs7xYzYQA==}
+  function.prototype.name@1.1.8:
+    resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
     engines: {node: '>= 0.4'}
 
   functions-have-names@1.2.3:
@@ -3405,8 +3420,8 @@ packages:
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
-  math-intrinsics@1.0.0:
-    resolution: {integrity: sha512-4MqMiKP90ybymYvsut0CH2g4XWbfLtmlCkXmtmdcDCxNB+mQcu1w/1+L/VD7vi/PSv7X2JYV7SCcR+jiPXnQtA==}
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
   mdast-util-directive@3.0.0:
@@ -3713,8 +3728,8 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
-  oniguruma-to-es@0.7.0:
-    resolution: {integrity: sha512-HRaRh09cE0gRS3+wi2zxekB+I5L8C/gN60S+vb11eADHUaB/q4u8wGGOX3GvwvitG8ixaeycZfeoyruKQzUgNg==}
+  oniguruma-to-es@0.8.0:
+    resolution: {integrity: sha512-rY+/a6b+uCgoYIL9itjY0x99UUDHXmGaw7Jjk5ZvM/3cxDJifyxFr/Zm4tTmF6Tre18gAakJo7AzhKUeMNLgHA==}
 
   open@10.1.0:
     resolution: {integrity: sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==}
@@ -3971,8 +3986,8 @@ packages:
   regenerator-transform@0.15.2:
     resolution: {integrity: sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==}
 
-  regex-recursion@4.3.0:
-    resolution: {integrity: sha512-5LcLnizwjcQ2ALfOj95MjcatxyqF5RPySx9yT+PaXu3Gox2vyAtLDjHB8NTJLtMGkvyau6nI3CfpwFCjPUIs/A==}
+  regex-recursion@5.0.0:
+    resolution: {integrity: sha512-UwyOqeobrCCqTXPcsSqH4gDhOjD5cI/b8kjngWgSZbxYh5yVjAwTjO5+hAuPRNiuR70+5RlWSs+U9PVcVcW9Lw==}
 
   regex-utilities@2.3.0:
     resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
@@ -4056,8 +4071,9 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
-  resolve@1.22.9:
-    resolution: {integrity: sha512-QxrmX1DzraFIi9PxdG5VkRfRwIgjwyud+z/iBwfRRrVmHc+P9Q7u2lSSpQ6bjr2gy5lrqIiU9vb6iAeGf2400A==}
+  resolve@1.22.10:
+    resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
+    engines: {node: '>= 0.4'}
     hasBin: true
 
   restore-cursor@3.1.0:
@@ -4098,6 +4114,11 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  runed@0.21.0:
+    resolution: {integrity: sha512-jqegxzCmUMrt11hGunWNVs9QVNJqOzqpC1a/UlPpDzHQ0YlSlsNhkfyt12bSaHlwHRdHcr7ZVxCxKVhWOVLcmw==}
+    peerDependencies:
+      svelte: ^5.7.0
 
   rxjs@6.6.7:
     resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==}
@@ -4173,8 +4194,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shiki@1.24.2:
-    resolution: {integrity: sha512-TR1fi6mkRrzW+SKT5G6uKuc32Dj2EEa7Kj0k8kGqiBINb+C1TiflVOiT9ta6GqOJtC4fraxO5SLUaKBcSY38Fg==}
+  shiki@1.24.3:
+    resolution: {integrity: sha512-eMeX/ehE2IDKVs71kB4zVcDHjutNcOtm+yIRuR4sA6ThBbdFI0DffGJiyoKCodj0xRGxIoWC3pk/Anmm5mzHmA==}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -4270,8 +4291,8 @@ packages:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
 
-  string.prototype.matchall@4.0.11:
-    resolution: {integrity: sha512-NUdh0aDavY2og7IbBPenWqR9exH+E26Sv8e0/eTe1tltDGZL+GtBkDAnnyBtmekfK6/Dq3MkcGtzXFEd1LQrtg==}
+  string.prototype.matchall@4.0.12:
+    resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
     engines: {node: '>= 0.4'}
 
   string.prototype.trim@1.2.10:
@@ -4518,8 +4539,8 @@ packages:
     resolution: {integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==}
     engines: {node: '>= 0.4'}
 
-  typed-array-byte-offset@1.0.3:
-    resolution: {integrity: sha512-GsvTyUHTriq6o/bHcTd0vM7OQ9JEdlvluu9YISaA7+KzDzPaIzEeDFNkTfhdE3MYcNhNi0vq/LlegYgIs5yPAw==}
+  typed-array-byte-offset@1.0.4:
+    resolution: {integrity: sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==}
     engines: {node: '>= 0.4'}
 
   typed-array-length@1.0.7:
@@ -4641,7 +4662,7 @@ packages:
     engines: {node: '>=14'}
     peerDependencies:
       '@unocss/webpack': 0.61.9
-      vite: ^6.0.0
+      vite: ^6.0.5
     peerDependenciesMeta:
       '@unocss/webpack':
         optional: true
@@ -4695,7 +4716,7 @@ packages:
     engines: {node: '>=14'}
     peerDependencies:
       '@nuxt/kit': '*'
-      vite: ^6.0.0
+      vite: ^6.0.5
     peerDependenciesMeta:
       '@nuxt/kit':
         optional: true
@@ -4705,15 +4726,15 @@ packages:
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@vite-pwa/assets-generator': ^0.2.6
-      vite: ^6.0.0
+      vite: ^6.0.5
       workbox-build: ^7.3.0
       workbox-window: ^7.3.0
     peerDependenciesMeta:
       '@vite-pwa/assets-generator':
         optional: true
 
-  vite@6.0.3:
-    resolution: {integrity: sha512-Cmuo5P0ENTN6HxLSo6IHsjCLn/81Vgrp81oaiFFMRa8gGDj5xEjIcEpf2ZymZtZR8oU0P2JX5WuUp/rlXcHkAw==}
+  vite@6.0.5:
+    resolution: {integrity: sha512-akD5IAH/ID5imgue2DYhzsEwCi0/4VKY31uhMLEYJwPP4TiUp8pL5PIK+Wo7H8qT8JY9i+pVfPydcFPYD1EL7g==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -4755,7 +4776,7 @@ packages:
   vitefu@1.0.4:
     resolution: {integrity: sha512-y6zEE3PQf6uu/Mt6DTJ9ih+kyJLr4XcSgHR2zUkM8SWDhuixEJxfJ6CZGMHh1Ec3vPLoEA0IHU5oWzVqw8ulow==}
     peerDependencies:
-      vite: ^6.0.0
+      vite: ^6.0.5
     peerDependenciesMeta:
       vite:
         optional: true
@@ -5172,7 +5193,7 @@ snapshots:
       '@babel/helper-plugin-utils': 7.25.9
       debug: 4.4.0
       lodash.debounce: 4.0.8
-      resolve: 1.22.9
+      resolve: 1.22.10
     transitivePeerDependencies:
       - supports-color
 
@@ -6256,8 +6277,8 @@ snapshots:
 
   '@gerrit0/mini-shiki@1.24.4':
     dependencies:
-      '@shikijs/engine-oniguruma': 1.24.2
-      '@shikijs/types': 1.24.2
+      '@shikijs/engine-oniguruma': 1.24.3
+      '@shikijs/types': 1.24.3
       '@shikijs/vscode-textmate': 9.3.1
 
   '@hono/node-server@1.13.7(hono@4.6.14)':
@@ -6385,7 +6406,7 @@ snapshots:
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-module: 1.0.0
-      resolve: 1.22.9
+      resolve: 1.22.10
     optionalDependencies:
       rollup: 2.79.2
 
@@ -6475,36 +6496,36 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.28.1':
     optional: true
 
-  '@shikijs/core@1.24.2':
+  '@shikijs/core@1.24.3':
     dependencies:
-      '@shikijs/engine-javascript': 1.24.2
-      '@shikijs/engine-oniguruma': 1.24.2
-      '@shikijs/types': 1.24.2
+      '@shikijs/engine-javascript': 1.24.3
+      '@shikijs/engine-oniguruma': 1.24.3
+      '@shikijs/types': 1.24.3
       '@shikijs/vscode-textmate': 9.3.1
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.4
 
-  '@shikijs/engine-javascript@1.24.2':
+  '@shikijs/engine-javascript@1.24.3':
     dependencies:
-      '@shikijs/types': 1.24.2
+      '@shikijs/types': 1.24.3
       '@shikijs/vscode-textmate': 9.3.1
-      oniguruma-to-es: 0.7.0
+      oniguruma-to-es: 0.8.0
 
-  '@shikijs/engine-oniguruma@1.24.2':
+  '@shikijs/engine-oniguruma@1.24.3':
     dependencies:
-      '@shikijs/types': 1.24.2
+      '@shikijs/types': 1.24.3
       '@shikijs/vscode-textmate': 9.3.1
 
-  '@shikijs/twoslash@1.24.2(typescript@5.7.2)':
+  '@shikijs/twoslash@1.24.3(typescript@5.7.2)':
     dependencies:
-      '@shikijs/core': 1.24.2
-      '@shikijs/types': 1.24.2
+      '@shikijs/core': 1.24.3
+      '@shikijs/types': 1.24.3
       twoslash: 0.2.12(typescript@5.7.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@shikijs/types@1.24.2':
+  '@shikijs/types@1.24.3':
     dependencies:
       '@shikijs/vscode-textmate': 9.3.1
       '@types/hast': 3.0.4
@@ -6518,19 +6539,19 @@ snapshots:
       ejs: 3.1.10
       json5: 2.2.3
       magic-string: 0.25.9
-      string.prototype.matchall: 4.0.11
+      string.prototype.matchall: 4.0.12
 
-  '@sveltejs/adapter-cloudflare@4.8.0(@sveltejs/kit@2.12.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(wrangler@3.96.0(@cloudflare/workers-types@4.20241218.0))':
+  '@sveltejs/adapter-cloudflare@4.9.0(@sveltejs/kit@2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(wrangler@3.96.0(@cloudflare/workers-types@4.20241218.0))':
     dependencies:
       '@cloudflare/workers-types': 4.20241218.0
-      '@sveltejs/kit': 2.12.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
+      '@sveltejs/kit': 2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
       esbuild: 0.24.0
       worktop: 0.8.0-next.18
       wrangler: 3.96.0(@cloudflare/workers-types@4.20241218.0)
 
-  '@sveltejs/kit@2.12.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))':
+  '@sveltejs/kit@2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.1.1
@@ -6544,50 +6565,50 @@ snapshots:
       sirv: 3.0.0
       svelte: 5.14.4
       tiny-glob: 0.2.9
-      vite: 6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
+      vite: 6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
       debug: 4.4.0
       svelte: 5.14.4
-      vite: 6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
+      vite: 6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))':
+  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
       debug: 4.4.0
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.17
       svelte: 5.14.4
-      vite: 6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
-      vitefu: 1.0.4(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
+      vite: 6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
+      vitefu: 1.0.4(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltepress/theme-default@5.0.5(q55a3n3uh4nvx5danag6r6gtau)':
+  '@sveltepress/theme-default@5.0.5(rbgpjl43s7mzugr5hgnsgubuf4)':
     dependencies:
       '@docsearch/css': 3.8.2
       '@docsearch/js': 3.8.2(@algolia/client-search@5.18.0)(search-insights@2.17.3)
-      '@shikijs/twoslash': 1.24.2(typescript@5.7.2)
-      '@sveltejs/kit': 2.12.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
+      '@shikijs/twoslash': 1.24.3(typescript@5.7.2)
+      '@sveltejs/kit': 2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
       '@sveltepress/twoslash': 1.1.5(svelte@5.14.4)(typescript@5.7.2)
-      '@sveltepress/vite': 1.1.2(@sveltejs/kit@2.12.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(rollup@2.79.2)(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
+      '@sveltepress/vite': 1.1.2(@sveltejs/kit@2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(rollup@2.79.2)(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
       '@unocss/extractor-svelte': 0.61.9
-      '@vite-pwa/sveltekit': 0.6.6(@sveltejs/kit@2.12.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(vite-plugin-pwa@0.21.1(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))(workbox-build@7.3.0)(workbox-window@7.3.0))
+      '@vite-pwa/sveltekit': 0.6.6(@sveltejs/kit@2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(vite-plugin-pwa@0.21.1(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))(workbox-build@7.3.0)(workbox-window@7.3.0))
       lru-cache: 10.4.3
       mdast-util-from-markdown: 2.0.2
       mdast-util-gfm: 3.0.0
-      shiki: 1.24.2
+      shiki: 1.24.3
       svelte: 5.14.4
       uid: 2.0.2
       unist-util-visit: 5.0.0
-      unocss: 0.61.9(postcss@8.4.49)(rollup@2.79.2)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
-      vite: 6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
+      unocss: 0.61.9(postcss@8.4.49)(rollup@2.79.2)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
+      vite: 6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
       workbox-precaching: 7.3.0
       workbox-routing: 7.3.0
     transitivePeerDependencies:
@@ -6607,11 +6628,11 @@ snapshots:
   '@sveltepress/twoslash@1.1.5(svelte@5.14.4)(typescript@5.7.2)':
     dependencies:
       '@floating-ui/dom': 1.6.12
-      '@shikijs/twoslash': 1.24.2(typescript@5.7.2)
+      '@shikijs/twoslash': 1.24.3(typescript@5.7.2)
       mdast-util-from-markdown: 2.0.2
       mdast-util-gfm: 3.0.0
       mdast-util-to-hast: 13.2.0
-      shiki: 1.24.2
+      shiki: 1.24.3
       source-map-js: 1.2.1
       svelte: 5.14.4
       svelte2tsx: 0.7.31(svelte@5.14.4)(typescript@5.7.2)
@@ -6621,10 +6642,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@sveltepress/vite@1.1.2(@sveltejs/kit@2.12.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(rollup@2.79.2)(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))':
+  '@sveltepress/vite@1.1.2(@sveltejs/kit@2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(rollup@2.79.2)(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))':
     dependencies:
-      '@sveltejs/kit': 2.12.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
+      '@sveltejs/kit': 2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
       cross-spawn: 7.0.6
       fs-extra: 11.2.0
       lru-cache: 10.4.3
@@ -6638,13 +6659,13 @@ snapshots:
       remark-parse: 11.0.0
       remark-rehype: 11.1.1
       remark-stringify: 11.0.0
-      shiki: 1.24.2
+      shiki: 1.24.3
       svelte: 5.14.4
       unified: 11.0.5
       unist-util-visit: 5.0.0
       vfile: 6.0.3
-      vite: 6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
-      vite-plugin-inspect: 0.8.9(rollup@2.79.2)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
+      vite: 6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
+      vite-plugin-inspect: 0.8.9(rollup@2.79.2)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
       yaml: 2.6.1
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -6795,13 +6816,13 @@ snapshots:
 
   '@ungap/structured-clone@1.2.1': {}
 
-  '@unocss/astro@0.61.9(rollup@2.79.2)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))':
+  '@unocss/astro@0.61.9(rollup@2.79.2)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))':
     dependencies:
       '@unocss/core': 0.61.9
       '@unocss/reset': 0.61.9
-      '@unocss/vite': 0.61.9(rollup@2.79.2)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
+      '@unocss/vite': 0.61.9(rollup@2.79.2)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
     optionalDependencies:
-      vite: 6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
+      vite: 6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -6816,7 +6837,7 @@ snapshots:
       cac: 6.7.14
       chokidar: 3.6.0
       colorette: 2.0.20
-      consola: 3.2.3
+      consola: 3.3.0
       fast-glob: 3.3.2
       magic-string: 0.30.17
       pathe: 1.1.2
@@ -6940,7 +6961,7 @@ snapshots:
     dependencies:
       '@unocss/core': 0.61.9
 
-  '@unocss/vite@0.61.9(rollup@2.79.2)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))':
+  '@unocss/vite@0.61.9(rollup@2.79.2)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@rollup/pluginutils': 5.1.4(rollup@2.79.2)
@@ -6952,17 +6973,17 @@ snapshots:
       chokidar: 3.6.0
       fast-glob: 3.3.2
       magic-string: 0.30.17
-      vite: 6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
+      vite: 6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  '@vite-pwa/sveltekit@0.6.6(@sveltejs/kit@2.12.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(vite-plugin-pwa@0.21.1(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))(workbox-build@7.3.0)(workbox-window@7.3.0))':
+  '@vite-pwa/sveltekit@0.6.6(@sveltejs/kit@2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(vite-plugin-pwa@0.21.1(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))(workbox-build@7.3.0)(workbox-window@7.3.0))':
     dependencies:
-      '@sveltejs/kit': 2.12.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
+      '@sveltejs/kit': 2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.14.4)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
       kolorist: 1.8.0
       tinyglobby: 0.2.10
-      vite-plugin-pwa: 0.21.1(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))(workbox-build@7.3.0)(workbox-window@7.3.0)
+      vite-plugin-pwa: 0.21.1(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))(workbox-build@7.3.0)(workbox-window@7.3.0)
 
   '@vitest/coverage-v8@2.1.8(vitest@2.1.8)':
     dependencies:
@@ -6989,13 +7010,13 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.8(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))':
+  '@vitest/mocker@2.1.8(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))':
     dependencies:
       '@vitest/spy': 2.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
+      vite: 6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
 
   '@vitest/pretty-format@2.1.8':
     dependencies:
@@ -7145,16 +7166,16 @@ snapshots:
 
   aria-query@5.3.2: {}
 
-  array-buffer-byte-length@1.0.1:
+  array-buffer-byte-length@1.0.2:
     dependencies:
-      call-bind: 1.0.8
+      call-bound: 1.0.3
       is-array-buffer: 3.0.5
 
   array-union@2.1.0: {}
 
   arraybuffer.prototype.slice@1.0.4:
     dependencies:
-      array-buffer-byte-length: 1.0.1
+      array-buffer-byte-length: 1.0.2
       call-bind: 1.0.8
       define-properties: 1.2.1
       es-abstract: 1.23.6
@@ -7251,7 +7272,7 @@ snapshots:
   browserslist@4.24.3:
     dependencies:
       caniuse-lite: 1.0.30001690
-      electron-to-chromium: 1.5.74
+      electron-to-chromium: 1.5.75
       node-releases: 2.0.19
       update-browserslist-db: 1.1.1(browserslist@4.24.3)
 
@@ -7414,7 +7435,7 @@ snapshots:
 
   confbox@0.1.8: {}
 
-  consola@3.2.3: {}
+  consola@3.3.0: {}
 
   content-disposition@0.5.2: {}
 
@@ -7445,21 +7466,21 @@ snapshots:
 
   data-uri-to-buffer@2.0.2: {}
 
-  data-view-buffer@1.0.1:
+  data-view-buffer@1.0.2:
     dependencies:
-      call-bind: 1.0.8
+      call-bound: 1.0.3
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
-  data-view-byte-length@1.0.1:
+  data-view-byte-length@1.0.2:
     dependencies:
-      call-bind: 1.0.8
+      call-bound: 1.0.3
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
-  data-view-byte-offset@1.0.0:
+  data-view-byte-offset@1.0.1:
     dependencies:
-      call-bind: 1.0.8
+      call-bound: 1.0.3
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
@@ -7561,7 +7582,7 @@ snapshots:
     dependencies:
       jake: 10.9.2
 
-  electron-to-chromium@1.5.74: {}
+  electron-to-chromium@1.5.75: {}
 
   emoji-regex-xs@1.0.0: {}
 
@@ -7584,20 +7605,20 @@ snapshots:
 
   es-abstract@1.23.6:
     dependencies:
-      array-buffer-byte-length: 1.0.1
+      array-buffer-byte-length: 1.0.2
       arraybuffer.prototype.slice: 1.0.4
       available-typed-arrays: 1.0.7
       call-bind: 1.0.8
       call-bound: 1.0.3
-      data-view-buffer: 1.0.1
-      data-view-byte-length: 1.0.1
-      data-view-byte-offset: 1.0.0
+      data-view-buffer: 1.0.2
+      data-view-byte-length: 1.0.2
+      data-view-byte-offset: 1.0.1
       es-define-property: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.0.0
       es-set-tostringtag: 2.0.3
       es-to-primitive: 1.3.0
-      function.prototype.name: 1.1.7
+      function.prototype.name: 1.1.8
       get-intrinsic: 1.2.6
       get-symbol-description: 1.1.0
       globalthis: 1.0.4
@@ -7616,7 +7637,7 @@ snapshots:
       is-string: 1.1.1
       is-typed-array: 1.1.15
       is-weakref: 1.1.0
-      math-intrinsics: 1.0.0
+      math-intrinsics: 1.1.0
       object-inspect: 1.13.3
       object-keys: 1.1.1
       object.assign: 4.1.7
@@ -7628,7 +7649,7 @@ snapshots:
       string.prototype.trimstart: 1.0.8
       typed-array-buffer: 1.0.3
       typed-array-byte-length: 1.0.3
-      typed-array-byte-offset: 1.0.3
+      typed-array-byte-offset: 1.0.4
       typed-array-length: 1.0.7
       unbox-primitive: 1.1.0
       which-typed-array: 1.1.18
@@ -8001,9 +8022,10 @@ snapshots:
 
   function-bind@1.1.2: {}
 
-  function.prototype.name@1.1.7:
+  function.prototype.name@1.1.8:
     dependencies:
       call-bind: 1.0.8
+      call-bound: 1.0.3
       define-properties: 1.2.1
       functions-have-names: 1.2.3
       hasown: 2.0.2
@@ -8026,7 +8048,7 @@ snapshots:
       gopd: 1.2.0
       has-symbols: 1.1.0
       hasown: 2.0.2
-      math-intrinsics: 1.0.0
+      math-intrinsics: 1.1.0
 
   get-own-enumerable-property-symbols@3.0.2: {}
 
@@ -8558,7 +8580,7 @@ snapshots:
 
   markdown-table@3.0.4: {}
 
-  math-intrinsics@1.0.0: {}
+  math-intrinsics@1.1.0: {}
 
   mdast-util-directive@3.0.0:
     dependencies:
@@ -9058,11 +9080,11 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  oniguruma-to-es@0.7.0:
+  oniguruma-to-es@0.8.0:
     dependencies:
       emoji-regex-xs: 1.0.0
       regex: 5.0.2
-      regex-recursion: 4.3.0
+      regex-recursion: 5.0.0
 
   open@10.1.0:
     dependencies:
@@ -9282,7 +9304,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.26.0
 
-  regex-recursion@4.3.0:
+  regex-recursion@5.0.0:
     dependencies:
       regex-utilities: 2.3.0
 
@@ -9405,7 +9427,7 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
-  resolve@1.22.9:
+  resolve@1.22.10:
     dependencies:
       is-core-module: 2.16.0
       path-parse: 1.0.7
@@ -9468,6 +9490,11 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  runed@0.21.0(svelte@5.14.4):
+    dependencies:
+      esm-env: 1.2.1
+      svelte: 5.14.4
 
   rxjs@6.6.7:
     dependencies:
@@ -9564,12 +9591,12 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shiki@1.24.2:
+  shiki@1.24.3:
     dependencies:
-      '@shikijs/core': 1.24.2
-      '@shikijs/engine-javascript': 1.24.2
-      '@shikijs/engine-oniguruma': 1.24.2
-      '@shikijs/types': 1.24.2
+      '@shikijs/core': 1.24.3
+      '@shikijs/engine-javascript': 1.24.3
+      '@shikijs/engine-oniguruma': 1.24.3
+      '@shikijs/types': 1.24.3
       '@shikijs/vscode-textmate': 9.3.1
       '@types/hast': 3.0.4
 
@@ -9674,9 +9701,10 @@ snapshots:
       emoji-regex: 9.2.2
       strip-ansi: 7.1.0
 
-  string.prototype.matchall@4.0.11:
+  string.prototype.matchall@4.0.12:
     dependencies:
       call-bind: 1.0.8
+      call-bound: 1.0.3
       define-properties: 1.2.1
       es-abstract: 1.23.6
       es-errors: 1.3.0
@@ -9941,7 +9969,7 @@ snapshots:
       has-proto: 1.2.0
       is-typed-array: 1.1.15
 
-  typed-array-byte-offset@1.0.3:
+  typed-array-byte-offset@1.0.4:
     dependencies:
       available-typed-arrays: 1.0.7
       call-bind: 1.0.8
@@ -10081,9 +10109,9 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unocss@0.61.9(postcss@8.4.49)(rollup@2.79.2)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)):
+  unocss@0.61.9(postcss@8.4.49)(rollup@2.79.2)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)):
     dependencies:
-      '@unocss/astro': 0.61.9(rollup@2.79.2)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
+      '@unocss/astro': 0.61.9(rollup@2.79.2)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
       '@unocss/cli': 0.61.9(rollup@2.79.2)
       '@unocss/core': 0.61.9
       '@unocss/extractor-arbitrary-variants': 0.61.9
@@ -10102,9 +10130,9 @@ snapshots:
       '@unocss/transformer-compile-class': 0.61.9
       '@unocss/transformer-directives': 0.61.9
       '@unocss/transformer-variant-group': 0.61.9
-      '@unocss/vite': 0.61.9(rollup@2.79.2)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
+      '@unocss/vite': 0.61.9(rollup@2.79.2)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
     optionalDependencies:
-      vite: 6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
+      vite: 6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
     transitivePeerDependencies:
       - postcss
       - rollup
@@ -10151,7 +10179,7 @@ snapshots:
       debug: 4.4.0
       es-module-lexer: 1.5.4
       pathe: 1.1.2
-      vite: 6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
+      vite: 6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -10166,7 +10194,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-inspect@0.8.9(rollup@2.79.2)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)):
+  vite-plugin-inspect@0.8.9(rollup@2.79.2)(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.1.4(rollup@2.79.2)
@@ -10177,23 +10205,23 @@ snapshots:
       perfect-debounce: 1.0.0
       picocolors: 1.1.1
       sirv: 3.0.0
-      vite: 6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
+      vite: 6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  vite-plugin-pwa@0.21.1(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))(workbox-build@7.3.0)(workbox-window@7.3.0):
+  vite-plugin-pwa@0.21.1(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))(workbox-build@7.3.0)(workbox-window@7.3.0):
     dependencies:
       debug: 4.4.0
       pretty-bytes: 6.1.1
       tinyglobby: 0.2.10
-      vite: 6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
+      vite: 6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
       workbox-build: 7.3.0
       workbox-window: 7.3.0
     transitivePeerDependencies:
       - supports-color
 
-  vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1):
+  vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1):
     dependencies:
       esbuild: 0.24.0
       postcss: 8.4.49
@@ -10206,14 +10234,14 @@ snapshots:
       tsx: 4.19.2
       yaml: 2.6.1
 
-  vitefu@1.0.4(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)):
+  vitefu@1.0.4(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)):
     optionalDependencies:
-      vite: 6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
+      vite: 6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
 
   vitest@2.1.8(@types/node@22.10.2)(@vitest/ui@2.1.8)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1):
     dependencies:
       '@vitest/expect': 2.1.8
-      '@vitest/mocker': 2.1.8(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
+      '@vitest/mocker': 2.1.8(vite@6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
       '@vitest/pretty-format': 2.1.8
       '@vitest/runner': 2.1.8
       '@vitest/snapshot': 2.1.8
@@ -10229,7 +10257,7 @@ snapshots:
       tinyexec: 0.3.1
       tinypool: 1.0.2
       tinyrainbow: 1.2.0
-      vite: 6.0.3(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
+      vite: 6.0.5(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
       vite-node: 2.1.8(@types/node@22.10.2)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -10275,7 +10303,7 @@ snapshots:
   which-builtin-type@1.2.1:
     dependencies:
       call-bound: 1.0.3
-      function.prototype.name: 1.1.7
+      function.prototype.name: 1.1.8
       has-tostringtag: 1.0.2
       is-async-function: 2.0.0
       is-date-object: 1.1.0
@@ -10460,7 +10488,7 @@ snapshots:
       miniflare: 3.20241205.0
       nanoid: 3.3.8
       path-to-regexp: 6.3.0
-      resolve: 1.22.9
+      resolve: 1.22.10
       selfsigned: 2.4.1
       source-map: 0.6.1
       unenv: unenv-nightly@2.0.0-20241204-140205-a5d5190

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,4 +10,4 @@ catalog:
   "svelte": "^5.14.4"
   "typescript": "^5.7.0"
   "valibot": "1.0.0-beta.9"
-  "vite": "^6.0.0"
+  "vite": "^6.0.5"

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,6 @@
+import mod from "node:module";
+
+import { vi } from "vitest";
+
+// FIXME: Ugly workaround for `import.meta.resolve` not working in Vitest: https://github.com/vitest-dev/vitest/issues/6953
+vi.stubGlobal("createRequire", mod.createRequire);

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -9,6 +9,7 @@ const __dirname = path.dirname(__filename);
 
 const SHARED = {
 	env: Object.assign(process.env, loadEnv("", path.resolve(__dirname), "")),
+	setupFiles: [path.resolve(__dirname, "tests", "setup.ts")],
 	snapshotSerializers: [path.resolve(__dirname, "tests", "snapshot-serializer.ts")],
 	typecheck: {
 		enabled: true,


### PR DESCRIPTION
🖥️  Live demo (PR preview): https://experiment-browser.svelte-docgen.pages.dev

This PR introduces some initial modifications to make svelte-docgen run in browser (or non-Node) runtimes using [TypeScript’s Official VFS](https://www.typescriptlang.org/dev/typescript-vfs/).

- Use `@typescript/vfs` to create a custom compiler host with VFS.
- Replace and polyfill `node:path` functionality using UnJS's `pathe`.