### PR TITLE
fix(extractor): Correct a cache key bug and prevent root_names reuse

### DIFF
--- a/.changeset/pink-pens-tickle.md
+++ b/.changeset/pink-pens-tickle.md
@@ -1,0 +1,5 @@
+---
+"@svelte-docgen/extractor": patch
+---
+
+Fix cache key in get_ts_config to use file path instead of source content

--- a/.changeset/pink-pens-tickle.md
+++ b/.changeset/pink-pens-tickle.md
@@ -2,4 +2,4 @@
 "@svelte-docgen/extractor": patch
 ---
 
-Fix cache key in get_ts_config to use file path instead of source content
+Fixed a cache key bug and resolved an issue caused by root_names reuse

--- a/packages/extractor/src/cache.js
+++ b/packages/extractor/src/cache.js
@@ -1,30 +1,4 @@
-// FIXME:
-// Find a better workaround.
-// Current issue: https://github.com/vitest-dev/vitest/issues/6953
-// We want to remove it, for the cross-runtime compatibility.
-import module from "node:module";
-
 import ts from "typescript";
-
-/**
- * @param {string} specifier
- * @returns {URL}
- */
-function get_node_module_filepath(specifier) {
-	if (typeof import.meta.resolve === "function") return new URL(import.meta.resolve(specifier));
-	const require = module.createRequire(import.meta.url);
-	return new URL(`file://${require.resolve(specifier)}`);
-}
-
-/**
- * @returns {string[]}
- */
-function create_default_root_names() {
-	return [
-		//
-		get_node_module_filepath("svelte2tsx/svelte-shims-v4.d.ts").pathname,
-	];
-}
 
 /**
  * @typedef CachedFile
@@ -39,8 +13,6 @@ class Cache {
 	#cached = new Map();
 	/** @type {ts.Program | undefined} */
 	program;
-	/** @type {Set<string>} */
-	root_names = new Set(create_default_root_names());
 	/**
 	 * @param {string} filepath
 	 * @returns {boolean}

--- a/packages/extractor/src/extractor/mod.js
+++ b/packages/extractor/src/extractor/mod.js
@@ -193,10 +193,10 @@ class Extractor {
 
 	/** @returns {ts.CompilerOptions} */
 	#get_ts_options() {
-		const cached = this.#cache.get(this.source)?.options;
+		const cached = this.#cache.get(this.compiler.filepath)?.options;
 		if (cached) return cached;
 		const options = this.#build_ts_options();
-		this.#cache.set(this.source, { options });
+		this.#cache.set(this.compiler.filepath, { options });
 		return options;
 	}
 


### PR DESCRIPTION
- Fixes the cache key in `get_ts_config` to use the filepath instead of the source content.
- This fix uncovers an additional issue caused by reusing root_names, which leads to files from previous extracts being included in the program. I’ve removed this reuse.