### PR TITLE
chore: Add GitHub's official labeler action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,34 @@
+"package:docgen":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "package/svelte-docgen/**"
+
+"package:extractor":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "package/extractor/**"
+
+"package:vite-plugin":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "package/vite-plugin-svelte-docgen/**"
+
+"package:server":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "package/server/**"
+
+"apps:docs":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "package/apps/docs/**"
+
+"documentation":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/README.md"
+
+"ci/cd":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "Labeler"
+on:
+  - pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5


### PR DESCRIPTION
I’d like to add this official action since we’re working on a monorepo.

> https://github.com/actions/labeler
> Automatically label new pull requests based on the paths of files being changed or the branch name.