### PR TITLE
fix(extractor): Default value handling for props with aliasing

### DIFF
--- a/.changeset/young-candles-warn.md
+++ b/.changeset/young-candles-warn.md
@@ -1,0 +1,5 @@
+---
+"@svelte-docgen/extractor": patch
+---
+
+Fix default value handling for props with aliasing

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,27 +1,27 @@
 "package:docgen":
   - changed-files:
       - any-glob-to-any-file:
-          - "package/svelte-docgen/**"
+          - "packages/svelte-docgen/**"
 
 "package:extractor":
   - changed-files:
       - any-glob-to-any-file:
-          - "package/extractor/**"
+          - "packages/extractor/**"
 
 "package:vite-plugin":
   - changed-files:
       - any-glob-to-any-file:
-          - "package/vite-plugin-svelte-docgen/**"
+          - "packages/vite-plugin-svelte-docgen/**"
 
 "package:server":
   - changed-files:
       - any-glob-to-any-file:
-          - "package/server/**"
+          - "packages/server/**"
 
-"apps:docs":
+"app:docs":
   - changed-files:
       - any-glob-to-any-file:
-          - "package/apps/docs/**"
+          - "apps/docs/**"
 
 "documentation":
   - changed-files:

--- a/packages/extractor/src/extractor/defaults.test.ts
+++ b/packages/extractor/src/extractor/defaults.test.ts
@@ -24,11 +24,13 @@ describe("defaults", () => {
 				import type { MouseEventHandler } from "svelte/elements";
 				interface Props {
 					id?: string;
+					class?: string;
 					onclick?: MouseEventHandler<HTMLButtonElement>;
 					disabled?: boolean;
 				}
 				let {
 					id = "button-123",
+					class: className = "primary",
 					onclick = () => {},
 					disabled,
 				}: Props = $props();
@@ -36,8 +38,9 @@ describe("defaults", () => {
 			<button {id} {onclick} {disabled}>Click me</button>
 		`;
 		const { defaults } = extract(source, create_options("modern-defaults.svelte"));
-		expect(defaults).toHaveLength(2);
+		expect(defaults).toHaveLength(3);
 		expect(defaults.get("id")?.getText()).toMatchInlineSnapshot(`""button-123""`);
+		expect(defaults.get("class")?.getText()).toMatchInlineSnapshot(`""primary""`);
 		expect(defaults.get("onclick")?.getText()).toMatchInlineSnapshot(`"() => {}"`);
 		expect(defaults.has("disabled")).toBe(false);
 	});

--- a/packages/extractor/src/extractor/mod.js
+++ b/packages/extractor/src/extractor/mod.js
@@ -65,7 +65,7 @@ class Extractor {
 		if (this.#props_obj) {
 			for (const binding of this.#props_obj?.elements ?? []) {
 				if (!binding.initializer) continue;
-				const name = binding.name.getText();
+				const name = binding.propertyName?.getText() || binding.name.getText();
 				results.set(name, binding.initializer);
 			}
 		} else {


### PR DESCRIPTION
Fixes #52 

```svelte
<script lang="ts">
  let { class: className = "foobar" }: {
    class?: string
  } = $props();
</script>
```

```json
{
  "exports": [],
  "isLegacy": false,
  "props": [
    [
      "class",
      {
        "tags": [],
        "isBindable": false,
        "isExtended": true,
        "isOptional": true,
        "type": {
          "kind": "union",
          "types": [
            {
              "kind": "undefined"
            },
            {
              "kind": "string"
            }
          ],
          "nonNullable": {
            "kind": "string"
          }
        },
        "default": {
          "kind": "literal",
          "subkind": "string",
          "value": "foobar"
        },
        "sources": [
          "src/Demo.svelte"
        ]
      }
    ]
  ]
}
```