### PR TITLE
refactor: Base compiler host initialization

### DIFF
--- a/apps/docs/src/routes/demo-playground/demo.ts
+++ b/apps/docs/src/routes/demo-playground/demo.ts
@@ -16,7 +16,7 @@ export function prepareDocgen(fsmap: Map<string, string>) {
 		const parsed = parse(source, {
 			cache,
 			filepath: "/src/Demo.svelte",
-			system: system,
+			sys: system,
 			host: tsvfs.createVirtualCompilerHost(system, {}, ts).compilerHost,
 		});
 		return encode(parsed, { indent: 2 });

--- a/packages/extractor/src/cache.js
+++ b/packages/extractor/src/cache.js
@@ -14,11 +14,11 @@ class Cache {
 	/** @type {ts.Program | undefined} */
 	program;
 	/** @type {ts.System} */
-	#system;
+	#sys;
 
-	/** @param {ts.System | undefined} system */
-	constructor(system) {
-		this.#system = system ?? ts.sys;
+	/** @param {ts.System | undefined} sys */
+	constructor(sys) {
+		this.#sys = sys ?? ts.sys;
 	}
 
 	/**
@@ -35,7 +35,7 @@ class Cache {
 	 */
 	get(filepath) {
 		const cached = this.#cached.get(filepath);
-		const last_modified = this.#system.getModifiedTime?.(filepath);
+		const last_modified = this.#sys.getModifiedTime?.(filepath);
 		if (cached?.last_modified?.getTime() === last_modified?.getTime()) return cached;
 	}
 
@@ -54,7 +54,7 @@ class Cache {
 	set(filepath, updated) {
 		const cached = this.#cached.get(filepath);
 		if (cached) return { ...cached, ...updated };
-		const last_modified = this.#system?.getModifiedTime?.(filepath);
+		const last_modified = this.#sys?.getModifiedTime?.(filepath);
 		const value = { ...updated, last_modified };
 		this.#cached.set(filepath, value);
 		return value;
@@ -62,7 +62,7 @@ class Cache {
 }
 
 /**
- * @param {ts.System} [system]
+ * @param {ts.System} [sys]
  * @returns {Cache}
  * */
-export const createCacheStorage = (system) => new Cache(system);
+export const createCacheStorage = (sys) => new Cache(sys);

--- a/packages/svelte-docgen/src/parser/mod.js
+++ b/packages/svelte-docgen/src/parser/mod.js
@@ -43,7 +43,7 @@ class Parser {
 	constructor(source, options) {
 		this.#options = options;
 		this.#extractor = extract(source, this.#options);
-		this.#root_path_url = get_root_path_url(this.#options.system);
+		this.#root_path_url = get_root_path_url(this.#options.sys);
 	}
 
 	/** @returns {ParsedComponent} */


### PR DESCRIPTION
Minor refactoring:

- The base compiler host initialization can be moved to the Option class
- Rename `system` -> `sys`