### PR TITLE
fix(docgen): Handle tuples as TypeReference and support instantiable types

### DIFF
--- a/.changeset/great-worms-tan.md
+++ b/.changeset/great-worms-tan.md
@@ -1,0 +1,5 @@
+---
+"svelte-docgen": patch
+---
+
+Fix to handle tuple as a TypeReference

--- a/.changeset/great-worms-tan.md
+++ b/.changeset/great-worms-tan.md
@@ -2,4 +2,4 @@
 "svelte-docgen": patch
 ---
 
-Fix to handle tuple as a TypeReference
+Fix handling of tuples as TypeReference and add support for instantiable types.

--- a/.changeset/great-worms-tan.md
+++ b/.changeset/great-worms-tan.md
@@ -2,4 +2,4 @@
 "svelte-docgen": patch
 ---
 
-Fix handling of tuples as TypeReference and add support for instantiable types.
+Fix to handle tuples as TypeReference

--- a/.changeset/pretty-rockets-tell.md
+++ b/.changeset/pretty-rockets-tell.md
@@ -1,0 +1,5 @@
+---
+"svelte-docgen": patch
+---
+
+Add support for instantiable types

--- a/apps/docs/src/routes/demo-playground/+page.svelte
+++ b/apps/docs/src/routes/demo-playground/+page.svelte
@@ -42,7 +42,7 @@
 			error = "";
 		} catch (e) {
 			error = String(e);
-			throw e;
+			console.error(e);
 		}
 	});
 </script>

--- a/apps/docs/src/routes/demo-playground/initial.txt
+++ b/apps/docs/src/routes/demo-playground/initial.txt
@@ -3,5 +3,11 @@
   interface B<T> { a: A };
   import { Snippet } from "svelte";
   type C = 1;
-  let {}: { a: A<number>, c: C, u: 1 | "foo", s: Snippet<[A<number>]> } = $props();
+  type R = number | [string | R];
+  let {}: {
+    a: A<number>,
+    c: C, u: 1 | "foo",
+    s: Snippet<[A<number>]>,
+    r: R,
+  } = $props();
 </script>

--- a/apps/docs/src/routes/demo-playground/initial.txt
+++ b/apps/docs/src/routes/demo-playground/initial.txt
@@ -9,10 +9,10 @@
     c: C, u: 1 | "foo",
     s: Snippet<[A<number>]>,
     r: R,
-	index: keyof K;
-	indexedAccess: number[keyof K];
-	conditional: K extends string ? true : false;
-	stringMapping: Uppercase<K>; 
-	templateLiteral: `Hello, ${K}!`;
+    index: keyof K;
+    indexedAccess: number[keyof K];
+    conditional: K extends string ? true : false;
+    stringMapping: Uppercase<K>; 
+    templateLiteral: `Hello, ${K}!`;
   } = $props();
 </script>

--- a/apps/docs/src/routes/demo-playground/initial.txt
+++ b/apps/docs/src/routes/demo-playground/initial.txt
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script lang="ts" generics="K">
   interface A<T> { b: B<T>, v: T };
   interface B<T> { a: A };
   import { Snippet } from "svelte";
@@ -9,5 +9,10 @@
     c: C, u: 1 | "foo",
     s: Snippet<[A<number>]>,
     r: R,
+	index: keyof K;
+	indexedAccess: number[keyof K];
+	conditional: K extends string ? true : false;
+	stringMapping: Uppercase<K>; 
+	templateLiteral: `Hello, ${K}!`;
   } = $props();
 </script>

--- a/packages/server/src/node/mod.test.ts
+++ b/packages/server/src/node/mod.test.ts
@@ -80,11 +80,7 @@ describe("NodeServer", () => {
 				              {
 				                "isOptional": false,
 				                "name": "args",
-				                "type": {
-				                  "elements": [],
-				                  "isReadonly": false,
-				                  "kind": "tuple",
-				                },
+				                "type": "[]",
 				              },
 				            ],
 				            "returns": {
@@ -113,6 +109,14 @@ describe("NodeServer", () => {
 				        "sources": Set {
 				          /node_modules/.pnpm/svelte@<semver>/node_modules/svelte/types/index.d.ts,
 				        },
+				      },
+				    ],
+				    [
+				      "[]",
+				      {
+				        "elements": [],
+				        "isReadonly": false,
+				        "kind": "tuple",
 				      },
 				    ],
 				    [

--- a/packages/server/src/node/mod.test.ts
+++ b/packages/server/src/node/mod.test.ts
@@ -122,6 +122,7 @@ describe("NodeServer", () => {
 				    [
 				      "SnippetReturn",
 				      {
+				        "alias": "SnippetReturn",
 				        "kind": "literal",
 				        "subkind": "symbol",
 				      },

--- a/packages/svelte-docgen/src/codec.test.ts
+++ b/packages/svelte-docgen/src/codec.test.ts
@@ -67,14 +67,7 @@ describe("encode()", () => {
 			              "kind": "undefined"
 			            },
 			            {
-			              "kind": "literal",
-			              "subkind": "boolean",
-			              "value": false
-			            },
-			            {
-			              "kind": "literal",
-			              "subkind": "boolean",
-			              "value": true
+			              "kind": "boolean"
 			            }
 			          ],
 			          "nonNullable": {

--- a/packages/svelte-docgen/src/doc/kind.js
+++ b/packages/svelte-docgen/src/doc/kind.js
@@ -48,6 +48,7 @@ export const TYPE_KIND = v.picklist([
 ]);
 
 /** @typedef {v.InferInput<typeof TYPE_KIND>} TypeKind */
+/** @typedef {v.InferInput<typeof BASE_TYPE_KIND>} BaseTypeKind */
 
 /**
  * @param {GetTypeParams} params

--- a/packages/svelte-docgen/src/doc/kind.js
+++ b/packages/svelte-docgen/src/doc/kind.js
@@ -29,13 +29,21 @@ export const ADVANCED_TYPE_KIND = v.picklist([
 	"intersection",
 	"literal",
 	"tuple",
-	"type-parameter",
 	"union",
+]);
+export const INSTANTIABLE_TYPE_KIND = v.picklist([
+	"type-parameter",
+	"index",
+	"indexed-access",
+	"conditional",
+	"template-literal",
+	"string-mapping",
 ]);
 export const TYPE_KIND = v.picklist([
 	//
 	...BASE_TYPE_KIND.options,
 	...ADVANCED_TYPE_KIND.options,
+	...INSTANTIABLE_TYPE_KIND.options,
 ]);
 
 /** @typedef {v.InferInput<typeof TYPE_KIND>} TypeKind */
@@ -54,11 +62,8 @@ export function get_type_kind(params) {
 	if (flags & ts.TypeFlags.Undefined) return "undefined";
 	if (flags & ts.TypeFlags.Unknown) return "unknown";
 	if (flags & ts.TypeFlags.Void) return "void";
-	if (flags & ts.TypeFlags.BigIntLiteral) return "literal";
-	if (flags & ts.TypeFlags.BooleanLiteral) return "literal";
-	if (flags & ts.TypeFlags.NumberLiteral) return "literal";
-	if (flags & ts.TypeFlags.StringLiteral) return "literal";
-	if (flags & ts.TypeFlags.UniqueESSymbol) return "literal";
+	if (flags & ts.TypeFlags.Literal) return "literal";
+	if (flags & ts.TypeFlags.UniqueESSymbol) return "literal"; // TODO: Is this correct?
 	if (flags & ts.TypeFlags.BigInt) return "bigint";
 	if (flags & ts.TypeFlags.Boolean) return "boolean";
 	if (flags & ts.TypeFlags.Number) return "number";
@@ -73,6 +78,11 @@ export function get_type_kind(params) {
 	if (type.isClassOrInterface()) return is_constructible(type, extractor) ? "constructible" : "interface";
 	if (type.getCallSignatures().length > 0) return "function";
 	if (type.isTypeParameter()) return "type-parameter";
+	if (flags & ts.TypeFlags.Index) return "index";
+	if (flags & ts.TypeFlags.IndexedAccess) return "indexed-access";
+	if (flags & ts.TypeFlags.Conditional) return "conditional";
+	if (flags & ts.TypeFlags.TemplateLiteral) return "template-literal";
+	if (flags & ts.TypeFlags.StringMapping) return "string-mapping";
 	// WARN: Must be last
 	if (is_object_type(type)) {
 		// FIXME: Sometimes the constructible type is not recognized with `ts.Type.isClassOrInterface()` - e.g. `Map` - don't know why.

--- a/packages/svelte-docgen/src/doc/kind.js
+++ b/packages/svelte-docgen/src/doc/kind.js
@@ -64,7 +64,7 @@ export function get_type_kind(params) {
 	if (flags & ts.TypeFlags.Unknown) return "unknown";
 	if (flags & ts.TypeFlags.Void) return "void";
 	if (flags & ts.TypeFlags.Literal) return "literal";
-	if (flags & ts.TypeFlags.UniqueESSymbol) return "literal"; // TODO: Is this correct?
+	if (flags & ts.TypeFlags.UniqueESSymbol) return "literal";
 	if (flags & ts.TypeFlags.BigInt) return "bigint";
 	if (flags & ts.TypeFlags.Boolean) return "boolean";
 	if (flags & ts.TypeFlags.Number) return "number";

--- a/packages/svelte-docgen/src/doc/kind.js
+++ b/packages/svelte-docgen/src/doc/kind.js
@@ -36,6 +36,7 @@ export const INSTANTIABLE_TYPE_KIND = v.picklist([
 	"index",
 	"indexed-access",
 	"conditional",
+	"substitution",
 	"template-literal",
 	"string-mapping",
 ]);
@@ -81,6 +82,7 @@ export function get_type_kind(params) {
 	if (flags & ts.TypeFlags.Index) return "index";
 	if (flags & ts.TypeFlags.IndexedAccess) return "indexed-access";
 	if (flags & ts.TypeFlags.Conditional) return "conditional";
+	if (flags & ts.TypeFlags.Substitution) return "substitution";
 	if (flags & ts.TypeFlags.TemplateLiteral) return "template-literal";
 	if (flags & ts.TypeFlags.StringMapping) return "string-mapping";
 	// WARN: Must be last

--- a/packages/svelte-docgen/src/doc/kind.js
+++ b/packages/svelte-docgen/src/doc/kind.js
@@ -64,14 +64,13 @@ export function get_type_kind(params) {
 	if (flags & ts.TypeFlags.Undefined) return "undefined";
 	if (flags & ts.TypeFlags.Unknown) return "unknown";
 	if (flags & ts.TypeFlags.Void) return "void";
-	if (flags & ts.TypeFlags.Literal) return "literal";
+	if (flags & ts.TypeFlags.Literal) return "literal"; // StringLiteral | NumberLiteral | BigIntLiteral | BooleanLiteral
 	if (flags & ts.TypeFlags.UniqueESSymbol) return "literal";
 	if (flags & ts.TypeFlags.BigInt) return "bigint";
 	if (flags & ts.TypeFlags.Boolean) return "boolean";
 	if (flags & ts.TypeFlags.Number) return "number";
 	if (flags & ts.TypeFlags.String) return "string";
 	if (flags & ts.TypeFlags.ESSymbol) return "symbol";
-	if (flags & ts.TypeFlags.ESSymbolLike) return "symbol";
 	if (extractor.checker.isTupleType(type)) return "tuple";
 	if (type.isIntersection()) return "intersection";
 	if (type.isUnion()) return "union";

--- a/packages/svelte-docgen/src/doc/type.ts
+++ b/packages/svelte-docgen/src/doc/type.ts
@@ -1,6 +1,6 @@
 import type { extract } from "@svelte-docgen/extractor";
 
-import type { TypeKind } from "./kind.js";
+import type { BaseTypeKind } from "./kind.js";
 
 /**
  * Type reference as key in the map {@link Types}.
@@ -111,19 +111,7 @@ export interface WithName {
 
 export interface BaseType {
 	/** @see {@link TypeKind} */
-	kind: Exclude<
-		TypeKind,
-		| "array"
-		| "constructible"
-		| "function"
-		| "interface"
-		| "intersection"
-		| "literal"
-		| "tuple"
-		| "union"
-		| "type-parameter"
-		| "index"
-	>;
+	kind: BaseTypeKind;
 }
 
 export interface ArrayType {

--- a/packages/svelte-docgen/src/doc/type.ts
+++ b/packages/svelte-docgen/src/doc/type.ts
@@ -220,8 +220,8 @@ export interface Index {
 
 export interface IndexedAccess {
 	kind: "indexed-access";
-	objectType: TypeOrRef;
-	indexType: TypeOrRef;
+	object: TypeOrRef;
+	index: TypeOrRef;
 	constraint?: TypeOrRef;
 	simplifiedForReading?: TypeOrRef;
 	simplifiedForWriting?: TypeOrRef;
@@ -229,15 +229,15 @@ export interface IndexedAccess {
 
 export interface Conditional {
 	kind: "conditional";
-	checkType: TypeOrRef;
-	extendsType: TypeOrRef;
-	resolvedTrueType?: TypeOrRef;
-	resolvedFalseType?: TypeOrRef;
+	check: TypeOrRef;
+	extends: TypeOrRef;
+	truthy?: TypeOrRef;
+	falsy?: TypeOrRef;
 }
 
 export interface Substitution {
 	kind: "substitution";
-	baseType: TypeOrRef;
+	base: TypeOrRef;
 	constraint: TypeOrRef;
 }
 

--- a/packages/svelte-docgen/src/doc/type.ts
+++ b/packages/svelte-docgen/src/doc/type.ts
@@ -22,7 +22,12 @@ export type Type =
 	| Literal
 	| Tuple
 	| TypeParam
-	| Union;
+	| Union
+	| Index
+	| IndexedAccess
+	| Conditional
+	| TemplateLiteral
+	| StringMapping;
 
 export type TypeOrRef = Type | TypeRef;
 
@@ -114,8 +119,9 @@ export interface BaseType {
 		| "intersection"
 		| "literal"
 		| "tuple"
-		| "type-parameter"
 		| "union"
+		| "type-parameter"
+		| "index"
 	>;
 }
 
@@ -204,6 +210,12 @@ export interface Tuple extends WithAlias {
 	elements: TypeOrRef[];
 }
 
+export interface Union extends WithAlias {
+	kind: "union";
+	types: TypeOrRef[];
+	nonNullable?: TypeOrRef;
+}
+
 export interface TypeParam {
 	kind: "type-parameter";
 	name: string;
@@ -212,8 +224,36 @@ export interface TypeParam {
 	default?: TypeOrRef;
 }
 
-export interface Union extends WithAlias {
-	kind: "union";
+export interface Index {
+	kind: "index";
+	type: TypeOrRef;
+}
+
+export interface IndexedAccess {
+	kind: "indexed-access";
+	objectType: TypeOrRef;
+	indexType: TypeOrRef;
+	constraint?: TypeOrRef;
+	simplifiedForReading?: TypeOrRef;
+	simplifiedForWriting?: TypeOrRef;
+}
+
+export interface Conditional {
+	kind: "conditional";
+	checkType: TypeOrRef;
+	extendsType: TypeOrRef;
+	resolvedTrueType?: TypeOrRef;
+	resolvedFalseType?: TypeOrRef;
+}
+
+export interface TemplateLiteral {
+	kind: "template-literal";
+	texts: readonly string[];
 	types: TypeOrRef[];
-	nonNullable?: TypeOrRef;
+}
+
+export interface StringMapping {
+	kind: "string-mapping";
+	type: TypeOrRef;
+	name: string;
 }

--- a/packages/svelte-docgen/src/doc/type.ts
+++ b/packages/svelte-docgen/src/doc/type.ts
@@ -26,6 +26,7 @@ export type Type =
 	| Index
 	| IndexedAccess
 	| Conditional
+	| Substitution
 	| TemplateLiteral
 	| StringMapping;
 
@@ -244,6 +245,12 @@ export interface Conditional {
 	extendsType: TypeOrRef;
 	resolvedTrueType?: TypeOrRef;
 	resolvedFalseType?: TypeOrRef;
+}
+
+export interface Substitution {
+	kind: "substitution";
+	baseType: TypeOrRef;
+	constraint: TypeOrRef;
 }
 
 export interface TemplateLiteral {

--- a/packages/svelte-docgen/src/doc/type.ts
+++ b/packages/svelte-docgen/src/doc/type.ts
@@ -223,8 +223,9 @@ export interface IndexedAccess {
 	object: TypeOrRef;
 	index: TypeOrRef;
 	constraint?: TypeOrRef;
-	simplifiedForReading?: TypeOrRef;
-	simplifiedForWriting?: TypeOrRef;
+	// TODO: Commenting these out for now as it's unclear if they are useful for users
+	// simplifiedForReading?: TypeOrRef;
+	// simplifiedForWriting?: TypeOrRef;
 }
 
 export interface Conditional {

--- a/packages/svelte-docgen/src/doc/type.ts
+++ b/packages/svelte-docgen/src/doc/type.ts
@@ -195,7 +195,7 @@ export interface LiteralString {
 export interface LiteralSymbol {
 	kind: "literal";
 	subkind: "symbol";
-	alias?: string;
+	alias: string;
 }
 export type Literal = LiteralBigInt | LiteralBoolean | LiteralNumber | LiteralString | LiteralSymbol;
 

--- a/packages/svelte-docgen/src/parser/mod.js
+++ b/packages/svelte-docgen/src/parser/mod.js
@@ -450,10 +450,13 @@ class Parser {
 			index: this.#get_type_doc(ia_type.indexType),
 		};
 		if (ia_type.constraint) results.constraint = this.#get_type_doc(ia_type.constraint);
-		if (ia_type.simplifiedForReading && ia_type.simplifiedForReading !== type)
-			results.simplifiedForReading = this.#get_type_doc(ia_type.simplifiedForReading);
-		if (ia_type.simplifiedForWriting && ia_type.simplifiedForWriting !== type)
-			results.simplifiedForReading = this.#get_type_doc(ia_type.simplifiedForWriting);
+
+		// TODO: Commenting these out for now as it's unclear if they are useful for users
+		//
+		// if (ia_type.simplifiedForReading && ia_type.simplifiedForReading !== type)
+		// 	results.simplifiedForReading = this.#get_type_doc(ia_type.simplifiedForReading);
+		// if (ia_type.simplifiedForWriting && ia_type.simplifiedForWriting !== type)
+		// 	results.simplifiedForReading = this.#get_type_doc(ia_type.simplifiedForWriting);
 		return results;
 	}
 

--- a/packages/svelte-docgen/src/parser/mod.js
+++ b/packages/svelte-docgen/src/parser/mod.js
@@ -446,8 +446,8 @@ class Parser {
 		/** @type {Doc.IndexedAccess} */
 		let results = {
 			kind: "indexed-access",
-			objectType: this.#get_type_doc(ia_type.objectType),
-			indexType: this.#get_type_doc(ia_type.indexType),
+			object: this.#get_type_doc(ia_type.objectType),
+			index: this.#get_type_doc(ia_type.indexType),
 		};
 		if (ia_type.constraint) results.constraint = this.#get_type_doc(ia_type.constraint);
 		if (ia_type.simplifiedForReading && ia_type.simplifiedForReading !== type)
@@ -469,12 +469,11 @@ class Parser {
 		/** @type {Doc.Conditional} */
 		let results = {
 			kind: "conditional",
-			checkType: this.#get_type_doc(conditional.checkType),
-			extendsType: this.#get_type_doc(conditional.extendsType),
+			check: this.#get_type_doc(conditional.checkType),
+			extends: this.#get_type_doc(conditional.extendsType),
 		};
-		if (conditional.resolvedTrueType) results.resolvedTrueType = this.#get_type_doc(conditional.resolvedTrueType);
-		if (conditional.resolvedFalseType)
-			results.resolvedFalseType = this.#get_type_doc(conditional.resolvedFalseType);
+		if (conditional.resolvedTrueType) results.truthy = this.#get_type_doc(conditional.resolvedTrueType);
+		if (conditional.resolvedFalseType) results.falsy = this.#get_type_doc(conditional.resolvedFalseType);
 		return results;
 	}
 
@@ -489,7 +488,7 @@ class Parser {
 		let substitution = /** @type {ts.SubstitutionType} */ (type);
 		return {
 			kind: "substitution",
-			baseType: this.#get_type_doc(substitution.baseType),
+			base: this.#get_type_doc(substitution.baseType),
 			constraint: this.#get_type_doc(substitution.constraint),
 		};
 	}

--- a/packages/svelte-docgen/src/parser/mod.js
+++ b/packages/svelte-docgen/src/parser/mod.js
@@ -463,7 +463,7 @@ class Parser {
 	#get_conditional_doc(type) {
 		// TODO: Document error
 		if (!(type.flags & ts.TypeFlags.Conditional))
-			throw new Error(`Expected Conditional type, got ${this.#checker.typeToString(type)}`);
+			throw new Error(`Expected conditional type, got ${this.#checker.typeToString(type)}`);
 		let conditional = /** @type {ts.ConditionalType} */ (type);
 		/** @type {Doc.Conditional} */
 		let results = {
@@ -475,6 +475,22 @@ class Parser {
 		if (conditional.resolvedFalseType)
 			results.resolvedFalseType = this.#get_type_doc(conditional.resolvedFalseType);
 		return results;
+	}
+
+	/**
+	 * @param {ts.Type} type
+	 * @returns {Doc.Substitution}
+	 */
+	#get_substitution_doc(type) {
+		// TODO: Document error
+		if (!(type.flags & ts.TypeFlags.Substitution))
+			throw new Error(`Expected substitution type, got ${this.#checker.typeToString(type)}`);
+		let substitution = /** @type {ts.SubstitutionType} */ (type);
+		return {
+			kind: "substitution",
+			baseType: this.#get_type_doc(substitution.baseType),
+			constraint: this.#get_type_doc(substitution.constraint),
+		};
 	}
 
 	/**
@@ -699,6 +715,8 @@ class Parser {
 				return this.#get_indexed_access_doc(type);
 			case "conditional":
 				return this.#get_conditional_doc(type);
+			case "substitution":
+				return this.#get_substitution_doc(type);
 			case "template-literal":
 				return this.#get_template_literal_doc(type);
 			case "string-mapping":

--- a/packages/svelte-docgen/src/parser/mod.js
+++ b/packages/svelte-docgen/src/parser/mod.js
@@ -300,6 +300,7 @@ class Parser {
 			return {
 				kind,
 				subkind: "symbol",
+				alias: this.#get_fully_qualified_name(/** @type {ts.UniqueESSymbolType} */ (type).symbol),
 			};
 		}
 		// TODO: Document error

--- a/packages/svelte-docgen/src/parser/props.test.ts
+++ b/packages/svelte-docgen/src/parser/props.test.ts
@@ -98,14 +98,7 @@ describe("props", () => {
 			          "kind": "undefined",
 			        },
 			        {
-			          "kind": "literal",
-			          "subkind": "boolean",
-			          "value": false,
-			        },
-			        {
-			          "kind": "literal",
-			          "subkind": "boolean",
-			          "value": true,
+			          "kind": "boolean",
 			        },
 			      ],
 			    },
@@ -125,14 +118,7 @@ describe("props", () => {
 			          "kind": "undefined",
 			        },
 			        {
-			          "kind": "literal",
-			          "subkind": "boolean",
-			          "value": false,
-			        },
-			        {
-			          "kind": "literal",
-			          "subkind": "boolean",
-			          "value": true,
+			          "kind": "boolean",
 			        },
 			      ],
 			    },
@@ -338,14 +324,7 @@ describe("props", () => {
 			        "kind": "null",
 			      },
 			      {
-			        "kind": "literal",
-			        "subkind": "boolean",
-			        "value": false,
-			      },
-			      {
-			        "kind": "literal",
-			        "subkind": "boolean",
-			        "value": true,
+			        "kind": "boolean",
 			      },
 			    ],
 			  },

--- a/packages/svelte-docgen/src/parser/type/function.test.ts
+++ b/packages/svelte-docgen/src/parser/type/function.test.ts
@@ -89,12 +89,7 @@ describe("Fn", () => {
 			              {
 			                "kind": "undefined",
 			              },
-			              {
-			                "kind": "string",
-			              },
-			              {
-			                "kind": "number",
-			              },
+			              "Baz",
 			            ],
 			          },
 			        },

--- a/packages/svelte-docgen/src/parser/type/instantiable.test.ts
+++ b/packages/svelte-docgen/src/parser/type/instantiable.test.ts
@@ -33,12 +33,12 @@ describe("Instantiable types", () => {
 		expect(indexedAccess.type?.kind).toBe("indexed-access");
 		expect(indexedAccess.type).toMatchInlineSnapshot(`
 			{
-			  "indexType": {
+			  "index": {
 			    "kind": "index",
 			    "type": "K",
 			  },
 			  "kind": "indexed-access",
-			  "objectType": {
+			  "object": {
 			    "kind": "number",
 			  },
 			}
@@ -49,23 +49,23 @@ describe("Instantiable types", () => {
 		const conditional = props.get("conditional");
 		if (!conditional?.type || isTypeRef(conditional?.type)) throw new Error("must be a type");
 		expect(conditional?.type.kind).toBe("conditional");
-		const resolvedTrueType = (conditional?.type as Doc.Conditional).resolvedTrueType!;
+		const resolvedTrueType = (conditional?.type as Doc.Conditional).truthy!;
 		if (isTypeRef(resolvedTrueType)) throw new Error("must be a type");
 		expect(resolvedTrueType.kind).toBe("substitution");
 		expect(conditional.type).toMatchInlineSnapshot(`
 			{
-			  "checkType": "K",
-			  "extendsType": {
+			  "check": "K",
+			  "extends": {
 			    "kind": "string",
 			  },
-			  "kind": "conditional",
-			  "resolvedFalseType": {
+			  "falsy": {
 			    "kind": "literal",
 			    "subkind": "boolean",
 			    "value": false,
 			  },
-			  "resolvedTrueType": {
-			    "baseType": "K",
+			  "kind": "conditional",
+			  "truthy": {
+			    "base": "K",
 			    "constraint": {
 			      "kind": "string",
 			    },

--- a/packages/svelte-docgen/src/parser/type/instantiable.test.ts
+++ b/packages/svelte-docgen/src/parser/type/instantiable.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "vitest";
 import { create_options } from "../../../tests/shared.js";
 import { parse } from "../mod.js";
 import { isTypeRef } from "../../doc/utils.js";
+import type * as Doc from "../../doc/type.js";
 
 describe("Instantiable types", () => {
 	const { props, types } = parse(
@@ -11,7 +12,7 @@ describe("Instantiable types", () => {
 			let { ..._ }: {
 			  index: keyof K;
 				indexedAccess: number[keyof K];
-				conditional: K extends string ? true : false;
+				conditional: K extends string ? K : false;
 				stringMapping: Uppercase<K>; 
 				templateLiteral: \`Hello, \${K}!\`;
 			} = $props();
@@ -48,6 +49,9 @@ describe("Instantiable types", () => {
 		const conditional = props.get("conditional");
 		if (!conditional?.type || isTypeRef(conditional?.type)) throw new Error("must be a type");
 		expect(conditional?.type.kind).toBe("conditional");
+		const resolvedTrueType = (conditional?.type as Doc.Conditional).resolvedTrueType!;
+		if (isTypeRef(resolvedTrueType)) throw new Error("must be a type");
+		expect(resolvedTrueType.kind).toBe("substitution");
 		expect(conditional.type).toMatchInlineSnapshot(`
 			{
 			  "checkType": "K",
@@ -61,9 +65,11 @@ describe("Instantiable types", () => {
 			    "value": false,
 			  },
 			  "resolvedTrueType": {
-			    "kind": "literal",
-			    "subkind": "boolean",
-			    "value": true,
+			    "baseType": "K",
+			    "constraint": {
+			      "kind": "string",
+			    },
+			    "kind": "substitution",
 			  },
 			}
 		`);

--- a/packages/svelte-docgen/src/parser/type/instantiable.test.ts
+++ b/packages/svelte-docgen/src/parser/type/instantiable.test.ts
@@ -1,0 +1,103 @@
+import { describe, it } from "vitest";
+
+import { create_options } from "../../../tests/shared.js";
+import { parse } from "../mod.js";
+import { isTypeRef } from "../../doc/utils.js";
+
+describe("Instantiable types", () => {
+	const { props, types } = parse(
+		`
+		<script lang="ts" generics="K">
+			let { ..._ }: {
+			  index: keyof K;
+				indexedAccess: number[keyof K];
+				conditional: K extends string ? true : false;
+				stringMapping: Uppercase<K>; 
+				templateLiteral: \`Hello, \${K}!\`;
+			} = $props();
+		</script>
+		`,
+		create_options("type-parameter.svelte"),
+	);
+
+	it("documents 'index'", ({ expect }) => {
+		const index = props.get("index");
+		if (!index?.type || isTypeRef(index?.type)) throw new Error("must be a type");
+		expect(index?.type.kind).toBe("index");
+	});
+
+	it("documents 'indexedAccess'", ({ expect }) => {
+		const indexedAccess = props.get("indexedAccess");
+		if (!indexedAccess?.type || isTypeRef(indexedAccess?.type)) throw new Error("must be a type");
+		expect(indexedAccess.type?.kind).toBe("indexed-access");
+		expect(indexedAccess.type).toMatchInlineSnapshot(`
+			{
+			  "indexType": {
+			    "kind": "index",
+			    "type": "K",
+			  },
+			  "kind": "indexed-access",
+			  "objectType": {
+			    "kind": "number",
+			  },
+			}
+		`);
+	});
+
+	it("documents 'conditional'", ({ expect }) => {
+		const conditional = props.get("conditional");
+		if (!conditional?.type || isTypeRef(conditional?.type)) throw new Error("must be a type");
+		expect(conditional?.type.kind).toBe("conditional");
+		expect(conditional.type).toMatchInlineSnapshot(`
+			{
+			  "checkType": "K",
+			  "extendsType": {
+			    "kind": "string",
+			  },
+			  "kind": "conditional",
+			  "resolvedFalseType": {
+			    "kind": "literal",
+			    "subkind": "boolean",
+			    "value": false,
+			  },
+			  "resolvedTrueType": {
+			    "kind": "literal",
+			    "subkind": "boolean",
+			    "value": true,
+			  },
+			}
+		`);
+	});
+
+	it("documents 'templateLiteral'", ({ expect }) => {
+		const templateLiteral = props.get("templateLiteral");
+		if (!templateLiteral?.type || isTypeRef(templateLiteral?.type)) throw new Error("must be a type");
+		expect(templateLiteral.type?.kind).toBe("template-literal");
+		expect(templateLiteral.type).toMatchInlineSnapshot(`
+			{
+			  "kind": "template-literal",
+			  "texts": [
+			    "Hello, ",
+			    "!",
+			  ],
+			  "types": [
+			    "K",
+			  ],
+			}
+		`);
+	});
+
+	it("documents 'stringMapping'", ({ expect }) => {
+		const stringMapping = props.get("stringMapping");
+		expect(stringMapping?.type).toBe("Uppercase");
+		const type = types.get("Uppercase");
+		expect(type?.kind).toBe("string-mapping");
+		expect(type).toMatchInlineSnapshot(`
+			{
+			  "kind": "string-mapping",
+			  "name": "Uppercase",
+			  "type": "K",
+			}
+		`);
+	});
+});

--- a/packages/svelte-docgen/src/parser/type/symbol.test.ts
+++ b/packages/svelte-docgen/src/parser/type/symbol.test.ts
@@ -1,0 +1,46 @@
+import { describe, it } from "vitest";
+import { create_options } from "../../../tests/shared.js";
+import type * as Doc from "../../doc/type.js";
+import { parse } from "../mod.js";
+
+describe("Symbol", () => {
+	const { props, types } = parse(
+		`
+			<script lang="ts">
+			  const sym: unique symbol = Symbol();
+				interface Props {
+					s: symbol;
+					us: typeof sym;
+				}
+				let { ..._ }: Props = $props();
+			</script>
+			`,
+		create_options("symbol.svelte"),
+	);
+
+	it("recognizes symbol", ({ expect }) => {
+		const sym = props.get("s");
+		expect(sym).toBeDefined();
+		expect(sym?.type).toMatchInlineSnapshot(`
+				{
+				  "kind": "symbol",
+				}
+			`);
+	});
+
+	it("recognizes unique symbol", ({ expect }) => {
+		const sym = props.get("us");
+		expect(sym).toBeDefined();
+		expect(sym?.type).toBe("sym");
+		const type = types.get("sym");
+		expect((type as Doc.Literal).kind).toBe("literal");
+		expect((type as Doc.Literal).subkind).toBe("symbol");
+		expect(type).toMatchInlineSnapshot(`
+			{
+			  "alias": "sym",
+			  "kind": "literal",
+			  "subkind": "symbol",
+			}
+		`);
+	});
+});

--- a/packages/svelte-docgen/src/parser/type/tuple.test.ts
+++ b/packages/svelte-docgen/src/parser/type/tuple.test.ts
@@ -106,14 +106,13 @@ describe("Tuple", () => {
 		expect(recursive?.type).toBe("Recursive");
 		const type = types.get("Recursive");
 		expect((type as Doc.Union)?.types.length).toBe(2);
-		const anon_id = (type as Doc.Union)?.types[1];
-		if (!isTypeRef(anon_id)) throw new Error("Expected type reference");
-		const anon_type = types.get(anon_id);
-		const anon_id2 = (anon_type as Doc.Tuple)?.elements[0];
-		if (!isTypeRef(anon_id2)) throw new Error("Expected type reference");
-		const anon_type2 = types.get(anon_id2);
-		expect(anon_type2?.kind).toBe("union");
-		expect((anon_type2 as Doc.Union)?.types.length).toBe(3);
+		const anon = (type as Doc.Union)?.types[1];
+		if (!isTypeRef(anon)) throw new Error("Expected type reference");
+		const anon_type = types.get(anon);
+		const anon2 = (anon_type as Doc.Tuple)?.elements[0];
+		if (isTypeRef(anon2)) throw new Error("Expected union");
+		expect(anon2?.kind).toBe("union");
+		expect((anon2 as Doc.Union)?.types.length).toBe(3);
 	});
 
 	it("collects aliased types", ({ expect }) => {
@@ -219,17 +218,28 @@ describe("Tuple", () => {
 			      {
 			        "kind": "number",
 			      },
-			      "[<anon:0>]",
+			      "[<anon:8>]",
 			    ],
 			  },
-			  "[<anon:0>]" => {
+			  "[<anon:8>]" => {
 			    "elements": [
-			      "<anon:0>",
+			      {
+			        "kind": "union",
+			        "types": [
+			          {
+			            "kind": "string",
+			          },
+			          {
+			            "kind": "number",
+			          },
+			          "[<anon:8>]",
+			        ],
+			      },
 			    ],
 			    "isReadonly": false,
 			    "kind": "tuple",
 			  },
-			  "<anon:0>" => {
+			  "<anon:8>" => {
 			    "kind": "union",
 			    "types": [
 			      {
@@ -238,7 +248,7 @@ describe("Tuple", () => {
 			      {
 			        "kind": "number",
 			      },
-			      "[<anon:0>]",
+			      "[<anon:8>]",
 			    ],
 			  },
 			}

--- a/packages/svelte-docgen/src/parser/type/type-parameter.test.ts
+++ b/packages/svelte-docgen/src/parser/type/type-parameter.test.ts
@@ -44,7 +44,6 @@ describe("TypeParam", () => {
 
 	it("recognizes `const`", ({ expect }) => {
 		const constant = props.get("constant");
-		console.log(constant);
 		if (!constant || isTypeRef(constant.type)) throw new Error("Expected a type");
 		expect(constant.type).toMatchInlineSnapshot(`
 			{
@@ -107,7 +106,6 @@ describe("TypeParam", () => {
 		if (isTypeRef(constraint)) throw new Error("Expected a type");
 		expect(constraint.kind).toBe("unknown");
 		const default2 = (default_.type as Doc.TypeParam).default as Doc.TypeParam;
-		console.log(default2);
 		if (!default2 || isTypeRef(default2)) throw new Error("Expected a type");
 		expect(default2.kind).toBe("string");
 	});

--- a/packages/svelte-docgen/src/parser/type/type-parameter.test.ts
+++ b/packages/svelte-docgen/src/parser/type/type-parameter.test.ts
@@ -6,7 +6,7 @@ import { parse } from "../mod.js";
 import { isTypeRef } from "../../doc/utils.js";
 
 describe("TypeParam", () => {
-	const { props } = parse(
+	const { props, types } = parse(
 		`
 		<script lang="ts" generics="U, const C, R extends number, D = string">
 			interface Props {
@@ -23,8 +23,9 @@ describe("TypeParam", () => {
 
 	it("documents unknown 'type-parameter'", ({ expect }) => {
 		const unknown = props.get("unknown");
-		if (!unknown || isTypeRef(unknown.type)) throw new Error("Expected a type");
-		expect(unknown.type).toMatchInlineSnapshot(`
+		expect(unknown?.type).toBe("U");
+		const type = types.get("U")!;
+		expect(type).toMatchInlineSnapshot(`
 			{
 			  "constraint": {
 			    "kind": "unknown",
@@ -34,18 +35,19 @@ describe("TypeParam", () => {
 			  "name": "U",
 			}
 		`);
-		expect(unknown.type.kind).toBe("type-parameter");
-		expect((unknown.type as Doc.TypeParam).isConst).toBe(false);
-		const constraint = (unknown?.type as Doc.TypeParam).constraint;
+		expect(type.kind).toBe("type-parameter");
+		expect((type as Doc.TypeParam).isConst).toBe(false);
+		const constraint = (type as Doc.TypeParam).constraint;
 		if (isTypeRef(constraint)) throw new Error("Expected a type");
 		expect(constraint.kind).toBe("unknown");
-		expect((unknown.type as Doc.TypeParam).default).not.toBeDefined();
+		expect((type as Doc.TypeParam).default).not.toBeDefined();
 	});
 
 	it("recognizes `const`", ({ expect }) => {
 		const constant = props.get("constant");
-		if (!constant || isTypeRef(constant.type)) throw new Error("Expected a type");
-		expect(constant.type).toMatchInlineSnapshot(`
+		expect(constant?.type).toBe("C");
+		const type = types.get("C")!;
+		expect(type).toMatchInlineSnapshot(`
 			{
 			  "constraint": {
 			    "kind": "unknown",
@@ -55,9 +57,9 @@ describe("TypeParam", () => {
 			  "name": "C",
 			}
 		`);
-		expect(constant.type.kind).toBe("type-parameter");
-		expect((constant.type as Doc.TypeParam).isConst).toBe(true);
-		const constraint = (constant?.type as Doc.TypeParam).constraint;
+		expect(type.kind).toBe("type-parameter");
+		expect((type as Doc.TypeParam).isConst).toBe(true);
+		const constraint = (type as Doc.TypeParam).constraint;
 		if (isTypeRef(constraint)) throw new Error("Expected a type");
 		expect(constraint.kind).toBe("unknown");
 		expect((constant?.type as Doc.TypeParam).default).not.toBeDefined();
@@ -65,8 +67,9 @@ describe("TypeParam", () => {
 
 	it("recognizes constraint", ({ expect }) => {
 		const constraint = props.get("constraint");
-		if (!constraint || isTypeRef(constraint.type)) throw new Error("Expected a type");
-		expect(constraint.type).toMatchInlineSnapshot(`
+		expect(constraint?.type).toBe("R");
+		const type = types.get("R")!;
+		expect(type).toMatchInlineSnapshot(`
 			{
 			  "constraint": {
 			    "kind": "number",
@@ -76,18 +79,19 @@ describe("TypeParam", () => {
 			  "name": "R",
 			}
 		`);
-		expect(constraint.type.kind).toBe("type-parameter");
-		expect((constraint.type as Doc.TypeParam).isConst).toBe(false);
-		const constraint2 = (constraint?.type as Doc.TypeParam).constraint;
+		expect(type.kind).toBe("type-parameter");
+		expect((type as Doc.TypeParam).isConst).toBe(false);
+		const constraint2 = (type as Doc.TypeParam).constraint;
 		if (isTypeRef(constraint2)) throw new Error("Expected a type");
 		expect(constraint2.kind).toBe("number");
-		expect((constraint.type as Doc.TypeParam).default).not.toBeDefined();
+		expect((type as Doc.TypeParam).default).not.toBeDefined();
 	});
 
 	it("recognizes default", ({ expect }) => {
 		const default_ = props.get("default");
-		if (!default_ || isTypeRef(default_.type)) throw new Error("Expected a type");
-		expect(default_.type).toMatchInlineSnapshot(`
+		expect(default_?.type).toBe("D");
+		const type = types.get("D")!;
+		expect(type).toMatchInlineSnapshot(`
 			{
 			  "constraint": {
 			    "kind": "unknown",
@@ -100,12 +104,12 @@ describe("TypeParam", () => {
 			  "name": "D",
 			}
 		`);
-		expect(default_.type.kind).toBe("type-parameter");
-		expect((default_.type as Doc.TypeParam).isConst).toBe(false);
-		const constraint = (default_?.type as Doc.TypeParam).constraint;
+		expect(type.kind).toBe("type-parameter");
+		expect((type as Doc.TypeParam).isConst).toBe(false);
+		const constraint = (type as Doc.TypeParam).constraint;
 		if (isTypeRef(constraint)) throw new Error("Expected a type");
 		expect(constraint.kind).toBe("unknown");
-		const default2 = (default_.type as Doc.TypeParam).default as Doc.TypeParam;
+		const default2 = (type as Doc.TypeParam).default as Doc.TypeParam;
 		if (!default2 || isTypeRef(default2)) throw new Error("Expected a type");
 		expect(default2.kind).toBe("string");
 	});


### PR DESCRIPTION
- Tuples are represented as TypeReference in TypeScript’s compiler API, which sometimes form anonymous circular structures even without aliases. Resolves: #67
- Add support for instantiable types. Resolves: #69