### PR TITLE
fix(vite-plugin): Handle 'types' in the AST transformation

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -4,6 +4,7 @@ ignore:
   - "**/examples/**"
   - "**/*.config.js"
   - "**/*.config.ts"
+  - "**/scripts/*.ts"
 
 coverage:
   status:

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,7 +1,7 @@
 ignore:
   - "**/lib/components/ui/**" # shadcn-svelte
   - "**/lib/components/app-sidebar/**" # shadcn-svelte
-  - "examples/component-documentation/**"
+  - "**/examples/**"
   - "**/*.config.js"
   - "**/*.config.ts"
 

--- a/packages/server/src/schema.js
+++ b/packages/server/src/schema.js
@@ -27,6 +27,7 @@ const PARSED_COMPONENT_FIELDS = /** @type {(keyof ParsedComponent)[]} */ ([
 	"events",
 	"exports",
 	"props",
+	"types",
 	"slots",
 	"tags",
 ]);

--- a/packages/vite-plugin-svelte-docgen/src/mod.test.ts
+++ b/packages/vite-plugin-svelte-docgen/src/mod.test.ts
@@ -26,6 +26,8 @@ describe("plugin", async () => {
 		expect(docgen.default.exports.size).toBe(0);
 		expect(docgen.default.props).toBeInstanceOf(Map);
 		expect(docgen.default.props.size).toBe(443);
+		expect(docgen.default.types).toBeInstanceOf(Map);
+		expect(docgen.default.types.size).toBe(101);
 	});
 
 	it("should handle both relative paths to importer and absolute paths from the project root", async ({ expect }) => {

--- a/packages/vite-plugin-svelte-docgen/src/mod.test.ts
+++ b/packages/vite-plugin-svelte-docgen/src/mod.test.ts
@@ -28,6 +28,7 @@ describe("plugin", async () => {
 		expect(docgen.default.props.size).toBe(443);
 		expect(docgen.default.types).toBeInstanceOf(Map);
 		expect(docgen.default.types.size).toBe(101);
+		expect(docgen.default.props.get("disabled").sources).toBeInstanceOf(Set);
 	});
 
 	it("should handle both relative paths to importer and absolute paths from the project root", async ({ expect }) => {

--- a/packages/vite-plugin-svelte-docgen/src/transform.js
+++ b/packages/vite-plugin-svelte-docgen/src/transform.js
@@ -34,20 +34,6 @@ export function transform_encoded(ast) {
 				typeof node.key.value === "string" &&
 				node.value.type === "ArrayExpression"
 			) {
-				/** Revive those keys values as {@link Map} */
-				if (["events", "exports", "props", "types", "slots"].includes(node.key.value)) {
-					return /** @type {AST.Property} */ ({
-						...node,
-						value: {
-							type: "NewExpression",
-							callee: {
-								type: "Identifier",
-								name: "Map",
-							},
-							arguments: [node.value],
-						},
-					});
-				}
 				/* Revive `sources` entry value as {@link Set} */
 				if (node.key.value === "sources") {
 					return /** @type {AST.Property} */ ({
@@ -61,6 +47,26 @@ export function transform_encoded(ast) {
 							arguments: [node.value],
 						},
 					});
+				}
+				const is_toplevel =
+					/** @type {AST.ObjectExpression} */ (ctx.path[ctx.path.length - 1]).properties.find(
+						(p) => p.type === "Property" && p.key.type === "Literal" && p.key.value === "props",
+					) !== undefined;
+				if (is_toplevel) {
+					/** Revive those keys values as {@link Map} */
+					if (["events", "exports", "props", "types", "slots"].includes(node.key.value)) {
+						return /** @type {AST.Property} */ ({
+							...node,
+							value: {
+								type: "NewExpression",
+								callee: {
+									type: "Identifier",
+									name: "Map",
+								},
+								arguments: [ctx.visit(node.value)],
+							},
+						});
+					}
 				}
 			}
 			// NOTE: Go to the next object property

--- a/packages/vite-plugin-svelte-docgen/src/transform.js
+++ b/packages/vite-plugin-svelte-docgen/src/transform.js
@@ -35,7 +35,7 @@ export function transform_encoded(ast) {
 				node.value.type === "ArrayExpression"
 			) {
 				/** Revive those keys values as {@link Map} */
-				if (["events", "exports", "props", "slots"].includes(node.key.value)) {
+				if (["events", "exports", "props", "types", "slots"].includes(node.key.value)) {
 					return /** @type {AST.Property} */ ({
 						...node,
 						value: {
@@ -44,8 +44,7 @@ export function transform_encoded(ast) {
 								type: "Identifier",
 								name: "Map",
 							},
-							// NOTE: Visit nested nodes _(if exists)_ to look for properties needed for further transformation
-							arguments: [ctx.visit(node.value)],
+							arguments: [node.value],
 						},
 					});
 				}


### PR DESCRIPTION
Follow-up to PR #79

I had forgotten to handle `types` in the AST transformation of our Vite plugin.