### PR TITLE
fix(docgen): Remove unnecessary "self" previously used for self-reference

### DIFF
--- a/packages/svelte-docgen/src/analyzer/prop.js
+++ b/packages/svelte-docgen/src/analyzer/prop.js
@@ -56,7 +56,6 @@ class PropAnalyzer {
 		// TODO: Document error
 		if (!call) throw new Error("");
 		const params = call.parameters[0];
-		if (params === "self") throw new Error("Self-referencing snippet is not supported");
 		// NOTE: Parameters is always a single item and tuple
 		const params_type = isTypeRef(params.type) ? this.#types.get(params.type) : params.type;
 		if (params_type?.kind !== "tuple") throw new Error("Not a tuple");

--- a/packages/svelte-docgen/src/doc/type.ts
+++ b/packages/svelte-docgen/src/doc/type.ts
@@ -142,7 +142,7 @@ export type FnParam = {
 } & (OptionalFnParam | RequiredFnParam);
 
 export interface FnCall {
-	parameters: (FnParam | "self")[];
+	parameters: FnParam[];
 	returns: TypeOrRef;
 }
 export interface Fn extends WithAlias {


### PR DESCRIPTION
We no longer need `"self"` for self-referencing due to the #61 changes, but some related logic and a type definition remain.