### PR TITLE
fix: Support for inline tags in props doc comments

### DIFF
--- a/.changeset/fluffy-mugs-work.md
+++ b/.changeset/fluffy-mugs-work.md
@@ -1,0 +1,6 @@
+---
+"svelte-docgen": minor
+"@svelte-docgen/extractor": minor
+---
+
+Support for inline tags in props doc comments

--- a/packages/extractor/src/extractor/component-doc.js
+++ b/packages/extractor/src/extractor/component-doc.js
@@ -3,15 +3,22 @@
  */
 
 /**
- * @typedef Tag
- * @prop {string} name
- * @prop {string} content
+ * @typedef DisplayPart
+ * @prop {string} kind
+ * @prop {string} text
  */
 
+/**
+ * @typedef Tag
+ * @prop {string} name
+ * @prop {DisplayPart[]} [content]
+ */
+
+// FIXME: Support for inline JSDoc/TSDoc tags in component documentation
 export class ComponentDocExtractor {
 	/** @type {AST.Comment} */
 	node;
-	/** @type {string | undefined} */
+	/** @type {DisplayPart[] | undefined} */
 	description;
 	/** @type {Tag[] | undefined} */
 	tags;
@@ -50,10 +57,10 @@ export class ComponentDocExtractor {
 
 	#wrap_latest_tag() {
 		const content = this.#latest_tag_content.join("\n").trim();
-		if (this.#latest_tag === "component") this.description = content;
+		if (this.#latest_tag === "component" && content) this.description = [{ kind: "text", text: content }];
 		else if (this.#latest_tag) {
 			if (!this.tags) this.tags = [];
-			this.tags.push({ name: this.#latest_tag, content });
+			this.tags.push({ name: this.#latest_tag, content: [{ kind: "text", text: content }] });
 		}
 		this.#latest_tag = undefined;
 		this.#latest_tag_content = [];

--- a/packages/extractor/src/extractor/component-doc.test.ts
+++ b/packages/extractor/src/extractor/component-doc.test.ts
@@ -5,7 +5,7 @@ import { ComponentDocExtractor } from "./component-doc.js";
 
 describe(ComponentDocExtractor.name, () => {
 	describe("description", () => {
-		it("returns empty string when no description is found, but other tags are present", ({ expect }) => {
+		it("returns undefined when no description is found, but other tags are present", ({ expect }) => {
 			const { componentComment } = new Parser(`
 				<!--
 				@component
@@ -16,8 +16,7 @@ describe(ComponentDocExtractor.name, () => {
 			expect(componentComment).toBeDefined();
 			if (componentComment) {
 				const { description } = new ComponentDocExtractor(componentComment);
-				expect(description).toBeDefined();
-				expect(description).toBe("");
+				expect(description).toBeUndefined();
 			}
 		});
 
@@ -33,7 +32,14 @@ describe(ComponentDocExtractor.name, () => {
 			if (componentComment) {
 				const { description } = new ComponentDocExtractor(componentComment);
 				expect(description).toBeDefined();
-				expect(description).toMatchInlineSnapshot(`"Native button component description"`);
+				expect(description).toMatchInlineSnapshot(`
+					[
+					  {
+					    "kind": "text",
+					    "text": "Native button component description",
+					  },
+					]
+				`);
 			}
 		});
 
@@ -55,7 +61,14 @@ describe(ComponentDocExtractor.name, () => {
 				const { description } = new ComponentDocExtractor(componentComment);
 				expect(description).toBeDefined();
 				expect(description).toMatchInlineSnapshot(
-					`"Leading an trailing whitespaces from description are removed."`,
+					`
+					[
+					  {
+					    "kind": "text",
+					    "text": "Leading an trailing whitespaces from description are removed.",
+					  },
+					]
+				`,
 				);
 			}
 		});
@@ -90,7 +103,10 @@ describe(ComponentDocExtractor.name, () => {
 				const { description } = new ComponentDocExtractor(componentComment);
 				expect(description).toBeDefined();
 				expect(description).toMatchInlineSnapshot(`
-					"This is first paragraph.
+					[
+					  {
+					    "kind": "text",
+					    "text": "This is first paragraph.
 
 
 					This is second paragraph.
@@ -102,7 +118,9 @@ describe(ComponentDocExtractor.name, () => {
 
 					---
 
-					This is footnote;"
+					This is footnote;",
+					  },
+					]
 				`);
 			}
 		});
@@ -135,11 +153,11 @@ describe(ComponentDocExtractor.name, () => {
 					expect(tags).toHaveLength(2);
 					expect(tags).toContainEqual({
 						name: "category",
-						content: "Atom",
+						content: [{ kind: "text", text: "Atom" }],
 					});
 					expect(tags).toContainEqual({
 						name: "subcategory",
-						content: "Semantic",
+						content: [{ kind: "text", text: "Semantic" }],
 					});
 				}
 			});
@@ -178,7 +196,10 @@ describe(ComponentDocExtractor.name, () => {
 					const customTag = tags?.find((tag) => tag.name === "custom");
 					expect(customTag).toBeDefined();
 					expect(customTag?.content).toMatchInlineSnapshot(`
-						"Very complex tag with {@link https://example.com}
+						[
+						  {
+						    "kind": "text",
+						    "text": "Very complex tag with {@link https://example.com}
 						and multi-line {@link https://example.com}.
 
 						It also should ignore markdownlint syntax unless some of lines starts with \`@\`.
@@ -197,7 +218,9 @@ describe(ComponentDocExtractor.name, () => {
 						| ------ | --- | ---- |
 						|        |     |      |
 
-						[text]: https://example.com"
+						[text]: https://example.com",
+						  },
+						]
 					`);
 				}
 			});

--- a/packages/extractor/src/extractor/mod.js
+++ b/packages/extractor/src/extractor/mod.js
@@ -6,7 +6,7 @@ import { Options } from "../options.js";
 import { Parser } from "../parser.js";
 
 /**
- * @import { Tag } from "./component-doc.js";
+ * @import { Tag, DisplayPart } from "./component-doc.js";
  * @import { Source } from "../util.js";
  * @import { createCacheStorage } from "../cache.js";
  */
@@ -35,7 +35,7 @@ class Extractor {
 		this.compiler = new Compiler(this.source, this.parser, this.#options);
 	}
 
-	/** @returns {string | undefined} */
+	/** @returns {DisplayPart[] | undefined} */
 	get description() {
 		return this.#component_doc_extractor?.description;
 	}

--- a/packages/svelte-docgen/src/analyzer/component.js
+++ b/packages/svelte-docgen/src/analyzer/component.js
@@ -14,12 +14,12 @@ class ComponentAnalyzer {
 
 	/** @returns {string | undefined} */
 	get category() {
-		return this.#component.tags?.find((t) => t.name === "category")?.content;
+		return this.#component.tags?.find((t) => t.name === "category")?.content?.[0]?.text;
 	}
 
 	/** @returns {string | undefined} */
 	get subcategory() {
-		return this.#component.tags?.find((t) => t.name === "subcategory")?.content;
+		return this.#component.tags?.find((t) => t.name === "subcategory")?.content?.[0]?.text;
 	}
 
 	/**

--- a/packages/svelte-docgen/src/doc/type.ts
+++ b/packages/svelte-docgen/src/doc/type.ts
@@ -58,9 +58,10 @@ export interface WithName {
  * Represents a documentation tag in JSDoc
  */
 export type Tag = NonNullable<ReturnType<typeof extract>["tags"]>[number];
+export type DisplayPart = NonNullable<Tag["content"]>[number];
 
 export interface Docable {
-	description?: string;
+	description?: DisplayPart[];
 	tags?: Tag[];
 }
 

--- a/packages/svelte-docgen/src/parser/component.test.ts
+++ b/packages/svelte-docgen/src/parser/component.test.ts
@@ -24,7 +24,14 @@ describe("description", () => {
 			create_options("parser-component-description-some.svelte"),
 		);
 		expect(description).toBeDefined();
-		expect(description).toMatchInlineSnapshot(`"This is a description that should be extracted."`);
+		expect(description).toMatchInlineSnapshot(`
+			[
+			  {
+			    "kind": "text",
+			    "text": "This is a description that should be extracted.",
+			  },
+			]
+		`);
 	});
 
 	it("ignores HTML comment at the root without `@component` tag", ({ expect }) => {
@@ -81,11 +88,11 @@ describe("tags", () => {
 		);
 		expect(tags).toBeDefined();
 		expect(tags).toContainEqual({
-			content: "Atom",
+			content: [{ kind: "text", text: "Atom" }],
 			name: "category",
 		});
 		expect(tags).toContainEqual({
-			content: "Native",
+			content: [{ kind: "text", text: "Native" }],
 			name: "subcategory",
 		});
 	});

--- a/packages/svelte-docgen/src/parser/mod.js
+++ b/packages/svelte-docgen/src/parser/mod.js
@@ -2,6 +2,7 @@
  * TODO: dts-buddy does not yet support `import * as Doc from "../doc/type.ts";`
  * @import {
  *	 Conditional,
+ *   DisplayPart,
  *	 Fn,
  *	 Index,
  *	 IndexedAccess,
@@ -353,12 +354,11 @@ class Parser {
 
 	/**
 	 * @param {ts.Symbol} symbol
-	 * @returns {string | undefined}
+	 * @returns {DisplayPart[] | undefined}
 	 */
 	#get_prop_description(symbol) {
 		const description = symbol.getDocumentationComment(this.#checker);
-		// TODO: Why it would be an array? Overloads? How should we handle it?
-		return description?.[0]?.text;
+		if (description && description.length) return description.map((d) => ({ text: d.text, kind: d.kind }));
 	}
 
 	/**
@@ -394,10 +394,9 @@ class Parser {
 	#get_prop_tags(symbol) {
 		return symbol.getJsDocTags(this.#checker).map((t) => {
 			/** @type {Tag} */
-			let results = { name: t.name, content: "" };
-			// TODO: Why it would be an array? Overloads? How should we handle it?
-			const content = t.text?.[0]?.text;
-			if (content) results.content = content;
+			let results = { name: t.name };
+			const content = t.text?.map((c) => ({ kind: c.kind, text: c.text }));
+			if (content && content.length) results.content = content;
 			return results;
 		});
 	}


### PR DESCRIPTION
Resolves #85

This PR modifies the structure around comments to add support for inline JSDoc/TSDoc tags in doc comments.

It adds support only for prop doc comments and does not address component docs, which will probably require a major overhaul of the parser. We will need to create a separate issue for component docs.