### PR TITLE
fix(analyser): Handling `isSnippet` in browser

### DIFF
--- a/.changeset/ten-ties-sniff.md
+++ b/.changeset/ten-ties-sniff.md
@@ -1,0 +1,5 @@
+---
+"svelte-docgen": patch
+---
+
+Fix incorrect handling of `analyzeProperty.isSnippet` in browser-like environments

--- a/packages/svelte-docgen/src/analyzer/prop.js
+++ b/packages/svelte-docgen/src/analyzer/prop.js
@@ -85,8 +85,8 @@ class PropAnalyzer {
 	#is_source_from_svelte(source) {
 		const { dir } = path.parse(source);
 		return (
-			dir.endsWith(path.join(path.sep, "node_modules", "svelte", "types")) ||
-			dir.endsWith(path.join(path.sep, "node_modules", "svelte"))
+			dir.endsWith(path.join("node_modules", "svelte", "types")) ||
+			dir.endsWith(path.join("node_modules", "svelte"))
 		);
 	}
 
@@ -95,7 +95,7 @@ class PropAnalyzer {
 	 * @returns {boolean}
 	 */
 	#is_snippet(type) {
-		if (type.kind !== "function" || type.alias !== '"svelte".Snippet') return false;
+		if (type.kind !== "function" || !type.alias?.startsWith('"svelte".Snippet')) return false;
 		if (!type.sources) return false;
 		return Iterator.from(type.sources).some((f) => this.#is_source_from_svelte(f));
 	}


### PR DESCRIPTION
This took me 1.5h~ to figure out... 😅 The devil always lies in those small details.

In browser, a path in `sources` set looks like this: `node_modules/svelte/types.d.ts`
...and our analyzer compares with `/node_mpdules/svelte/types.d.ts`

The frigging `/` at the start!!!

Addidtionally improved check, in case the snippet has parameters.
I noticed previously it was returning `true` only if this doesn't have parameters at all.
