### PR TITLE
fix: Remove leading `/` of paths inside the `sources` set

### DIFF
--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -25,7 +25,7 @@ describe("POST /", () => {
 		expect(response.status).toBe(200);
 		const data = await response.json();
 		expect(data).toMatchInlineSnapshot(
-			`"{"props":[["custom",{"tags":[],"isBindable":false,"isExtended":true,"isOptional":false,"type":{"kind":"string"},"sources":["/packages/server/examples/test.svelte"]}],["children",{"tags":[],"isBindable":false,"isExtended":true,"isOptional":true,"type":{"kind":"union","types":["\\"svelte\\".Snippet<[]>",{"kind":"undefined"}],"nonNullable":"\\"svelte\\".Snippet<[]>"},"sources":["/packages/server/examples/test.svelte"]}]]}"`,
+			`"{"props":[["custom",{"tags":[],"isBindable":false,"isExtended":true,"isOptional":false,"type":{"kind":"string"},"sources":["packages/server/examples/test.svelte"]}],["children",{"tags":[],"isBindable":false,"isExtended":true,"isOptional":true,"type":{"kind":"union","types":["\\"svelte\\".Snippet<[]>",{"kind":"undefined"}],"nonNullable":"\\"svelte\\".Snippet<[]>"},"sources":["packages/server/examples/test.svelte"]}]]}"`,
 		);
 	});
 

--- a/packages/server/src/node/mod.test.ts
+++ b/packages/server/src/node/mod.test.ts
@@ -42,7 +42,7 @@ describe("NodeServer", () => {
 				      "isExtended": true,
 				      "isOptional": false,
 				      "sources": Set {
-				        "/packages/server/examples/test.svelte",
+				        "packages/server/examples/test.svelte",
 				      },
 				      "tags": [],
 				      "type": {
@@ -54,7 +54,7 @@ describe("NodeServer", () => {
 				      "isExtended": true,
 				      "isOptional": true,
 				      "sources": Set {
-				        "/packages/server/examples/test.svelte",
+				        "packages/server/examples/test.svelte",
 				      },
 				      "tags": [],
 				      "type": {
@@ -105,7 +105,7 @@ describe("NodeServer", () => {
 				      ],
 				      "kind": "function",
 				      "sources": Set {
-				        /node_modules/.pnpm/svelte@<semver>/node_modules/svelte/types/index.d.ts,
+				        node_modules/.pnpm/svelte@<semver>/node_modules/svelte/types/index.d.ts,
 				      },
 				    },
 				    "[]" => {

--- a/packages/svelte-docgen/src/analyzer/prop.test.ts
+++ b/packages/svelte-docgen/src/analyzer/prop.test.ts
@@ -81,7 +81,7 @@ describe(analyzeProperty.name, () => {
 					  "isExtended": true,
 					  "isOptional": false,
 					  "sources": Set {
-					    "/packages/svelte-docgen/tests/custom-extended.ts",
+					    "packages/svelte-docgen/tests/custom-extended.ts",
 					  },
 					  "tags": [],
 					  "type": {

--- a/packages/svelte-docgen/src/codec.test.ts
+++ b/packages/svelte-docgen/src/codec.test.ts
@@ -238,9 +238,9 @@ describe("encode()", () => {
 			          ]
 			        ],
 			        "sources": [
-			          "/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es5.d.ts",
-			          "/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
-			          "/node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2020.date.d.ts"
+			          "node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es5.d.ts",
+			          "node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+			          "node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2020.date.d.ts"
 			        ]
 			      }
 			    ]

--- a/packages/svelte-docgen/src/parser/props.test.ts
+++ b/packages/svelte-docgen/src/parser/props.test.ts
@@ -339,5 +339,21 @@ describe("props", () => {
 		if (disabled?.isExtended && disabled?.sources) {
 			expect(Iterator.from(disabled.sources).some((s) => s.endsWith("/svelte/elements.d.ts")));
 		}
+		const custom = props.get("custom");
+		expect(custom).toBeDefined();
+		expect(custom).toMatchInlineSnapshot(`
+			{
+			  "isBindable": false,
+			  "isExtended": false,
+			  "isOptional": false,
+			  "tags": [],
+			  "type": {
+			    "kind": "string",
+			  },
+			}
+		`);
+		if (custom) {
+			expect(custom.isExtended).toBe(false);
+		}
 	});
 });

--- a/packages/svelte-docgen/src/parser/props.test.ts
+++ b/packages/svelte-docgen/src/parser/props.test.ts
@@ -308,7 +308,7 @@ describe("props", () => {
 			  "isExtended": true,
 			  "isOptional": true,
 			  "sources": Set {
-			    /node_modules/.pnpm/svelte@<semver>/node_modules/svelte/elements.d.ts,
+			    node_modules/.pnpm/svelte@<semver>/node_modules/svelte/elements.d.ts,
 			  },
 			  "tags": [],
 			  "type": {
@@ -333,7 +333,7 @@ describe("props", () => {
 		expect(disabled?.isExtended).toBe(true);
 		expect(disabled?.sources).toMatchInlineSnapshot(`
 			Set {
-			  /node_modules/.pnpm/svelte@<semver>/node_modules/svelte/elements.d.ts,
+			  node_modules/.pnpm/svelte@<semver>/node_modules/svelte/elements.d.ts,
 			}
 		`);
 		if (disabled?.isExtended && disabled?.sources) {

--- a/packages/svelte-docgen/src/parser/type/constructible.test.ts
+++ b/packages/svelte-docgen/src/parser/type/constructible.test.ts
@@ -244,9 +244,9 @@ describe("Constructible", () => {
 			  "kind": "constructible",
 			  "name": "Date",
 			  "sources": Set {
-			    /node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es5.d.ts,
-			    /node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts,
-			    /node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2020.date.d.ts,
+			    node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es5.d.ts,
+			    node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts,
+			    node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2020.date.d.ts,
 			  },
 			}
 		`);
@@ -305,9 +305,9 @@ describe("Constructible", () => {
 			  "kind": "constructible",
 			  "name": "Map",
 			  "sources": Set {
-			    /node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.collection.d.ts,
-			    /node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.iterable.d.ts,
-			    /node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts,
+			    node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.collection.d.ts,
+			    node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.iterable.d.ts,
+			    node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts,
 			  },
 			}
 		`);
@@ -364,10 +364,10 @@ describe("Constructible", () => {
 			  "kind": "constructible",
 			  "name": "Set",
 			  "sources": Set {
-			    /node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.collection.d.ts,
-			    /node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.iterable.d.ts,
-			    /node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts,
-			    /node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.esnext.collection.d.ts,
+			    node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.collection.d.ts,
+			    node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.iterable.d.ts,
+			    node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts,
+			    node_modules/.pnpm/typescript@<semver>/node_modules/typescript/lib/lib.esnext.collection.d.ts,
 			  },
 			}
 		`);

--- a/packages/svelte-docgen/src/shared.js
+++ b/packages/svelte-docgen/src/shared.js
@@ -133,7 +133,7 @@ export function get_sources(declarations, root_path_url) {
 			return d
 				.getSourceFile()
 				.fileName.replace(".tsx", "")
-				.replace(root_path_url.pathname, "");
+				.replace(root_path_url.pathname + pathe.sep, "");
 		}),
 	);
 }


### PR DESCRIPTION
Resolves #93

Is a frigging leading path separator `/` again. So, I made a solution that we no longer include it in `sources` set paths