### PR TITLE
fix: Allow more types to be aliased

### DIFF
--- a/packages/server/src/node/mod.test.ts
+++ b/packages/server/src/node/mod.test.ts
@@ -114,8 +114,8 @@ describe("NodeServer", () => {
 				      "kind": "tuple",
 				    },
 				    "SnippetReturn" => {
-				      "alias": "SnippetReturn",
 				      "kind": "literal",
+				      "name": "SnippetReturn",
 				      "subkind": "symbol",
 				    },
 				  },

--- a/packages/svelte-docgen/src/doc/type.ts
+++ b/packages/svelte-docgen/src/doc/type.ts
@@ -51,7 +51,7 @@ export interface WithName {
 	/**
 	 * Where is this type declared?
 	 */
-	sources: Set<string>;
+	sources?: Set<string>;
 }
 
 /**
@@ -94,37 +94,21 @@ export type Props = Map<string, Prop>;
 export type Slots = Map<string, Props>;
 export type Types = Map<TypeRef, (Type & WithAlias) | (Type & WithName)>;
 
-export interface WithAlias {
-	alias?: string;
-	/**
-	 * Where is this type declared?
-	 */
-	sources?: Set<string>;
-}
-
-export interface WithName {
-	name: string;
-	/**
-	 * Where is this type declared?
-	 */
-	sources: Set<string>;
-}
-
 export interface BaseType {
 	/** @see {@link TypeKind} */
 	kind: BaseTypeKind;
 }
 
-export interface ArrayType {
+export interface ArrayType extends WithAlias {
 	kind: "array";
 	isReadonly: boolean;
 	element: TypeOrRef;
 }
 
-export interface Constructible extends WithName {
+export interface Constructible extends WithName, WithAlias {
 	kind: "constructible";
 	name: string;
-	constructors: globalThis.Array<FnParam[]>;
+	constructors: FnParam[][];
 }
 
 export interface OptionalFnParam {
@@ -184,7 +168,7 @@ export interface LiteralString {
 export interface LiteralSymbol {
 	kind: "literal";
 	subkind: "symbol";
-	alias: string;
+	name: string;
 }
 export type Literal = LiteralBigInt | LiteralBoolean | LiteralNumber | LiteralString | LiteralSymbol;
 
@@ -219,7 +203,7 @@ export interface Index {
 	type: TypeOrRef;
 }
 
-export interface IndexedAccess {
+export interface IndexedAccess extends WithAlias {
 	kind: "indexed-access";
 	object: TypeOrRef;
 	index: TypeOrRef;
@@ -229,7 +213,7 @@ export interface IndexedAccess {
 	// simplifiedForWriting?: TypeOrRef;
 }
 
-export interface Conditional {
+export interface Conditional extends WithAlias {
 	kind: "conditional";
 	check: TypeOrRef;
 	extends: TypeOrRef;

--- a/packages/svelte-docgen/src/parser/type/array.test.ts
+++ b/packages/svelte-docgen/src/parser/type/array.test.ts
@@ -10,9 +10,11 @@ describe("Array", () => {
 		<script lang="ts">
 			type Letter = "a" | "b" | "c";
 			type Num = 0 | 1 | 2;
+			type Aliased = number[];
 			interface Props {
 				letters: Letter[];
 				numbers: readonly Num[];
+				aliased: Aliased;
 			}
 			let { ..._ }: Props = $props();
 		</script>
@@ -89,6 +91,16 @@ describe("Array", () => {
 			      "value": 2,
 			    },
 			  ],
+			}
+		`);
+		expect(types.get("Aliased")).toMatchInlineSnapshot(`
+			{
+			  "alias": "Aliased",
+			  "element": {
+			    "kind": "number",
+			  },
+			  "isReadonly": false,
+			  "kind": "array",
 			}
 		`);
 	});

--- a/packages/svelte-docgen/src/parser/type/constructible.test.ts
+++ b/packages/svelte-docgen/src/parser/type/constructible.test.ts
@@ -18,8 +18,13 @@ describe("Constructible", () => {
 					this.baz = baz;
 				}
 			}
+			class Custom2<T> {
+			  foo: T;
+			}
+			type Aliased = Custom2<string>;
 			interface Props {
 				custom: Custom;
+				aliased: Aliased;
 				date: Date;
 				map: Map<string, number>;
 				set: Set<string>;
@@ -82,6 +87,26 @@ describe("Constructible", () => {
 			  ],
 			  "kind": "constructible",
 			  "name": "Custom",
+			  "sources": Set {
+			    "constructible.svelte",
+			  },
+			}
+		`);
+	});
+
+	it("recognizes 'aliased'", ({ expect }) => {
+		const aliased = props.get("aliased");
+		expect(aliased?.type).toBe("Aliased");
+		const type = types.get("Aliased");
+		expect(type?.kind).toBe("constructible");
+		expect(type).toMatchInlineSnapshot(`
+			{
+			  "alias": "Aliased",
+			  "constructors": [
+			    [],
+			  ],
+			  "kind": "constructible",
+			  "name": "Custom2",
 			  "sources": Set {
 			    "constructible.svelte",
 			  },

--- a/packages/svelte-docgen/src/parser/type/literal.test.ts
+++ b/packages/svelte-docgen/src/parser/type/literal.test.ts
@@ -142,11 +142,12 @@ describe("Literal", () => {
 	});
 
 	describe("LiteralSymbol", () => {
-		const { props } = parse(
+		const { props, types } = parse(
 			`
 			<script lang="ts">
+			  const sym: unique symbol = Symbol(); 
 				interface Props {
-					reality: unique symbol;
+					reality: typeof sym;
 				}
 				let { ..._ }: Props = $props();
 			</script>
@@ -157,9 +158,12 @@ describe("Literal", () => {
 		it("documents 'literal' type - symbol", ({ expect }) => {
 			const reality = props.get("reality");
 			expect(reality).toBeDefined();
-			expect(reality?.type).toMatchInlineSnapshot(`
+			expect(reality?.type).toBe("sym");
+			expect(types.get("sym")).toMatchInlineSnapshot(`
 				{
-				  "kind": "symbol",
+				  "kind": "literal",
+				  "name": "sym",
+				  "subkind": "symbol",
 				}
 			`);
 		});

--- a/packages/svelte-docgen/src/parser/type/symbol.test.ts
+++ b/packages/svelte-docgen/src/parser/type/symbol.test.ts
@@ -37,8 +37,8 @@ describe("Symbol", () => {
 		expect((type as Doc.Literal).subkind).toBe("symbol");
 		expect(type).toMatchInlineSnapshot(`
 			{
-			  "alias": "sym",
 			  "kind": "literal",
+			  "name": "sym",
 			  "subkind": "symbol",
 			}
 		`);


### PR DESCRIPTION
This PR adds aliasing support for `array`, `constructible`, `indexed-access`, and `conditional`.

That said, I believe we need a more fundamental refactoring or changes regarding "alias" and "name" next.