### PR TITLE
refactor(docgen): Simplify get_type_kind

### DIFF
--- a/packages/svelte-docgen/src/parser/mod.js
+++ b/packages/svelte-docgen/src/parser/mod.js
@@ -48,7 +48,7 @@ import {
 	is_const_type_param,
 	is_symbol_optional,
 	is_symbol_readonly,
-	is_tuple_type,
+	is_tuple_type_reference,
 	is_type_reference,
 } from "../shared.js";
 import { isTypeRef } from "../doc/utils.js";
@@ -419,10 +419,7 @@ class Parser {
 	 */
 	#get_tuple_doc(type) {
 		// TODO: Document error
-		if (!is_type_reference(type))
-			throw new Error(`Expected type reference, got ${this.#checker.typeToString(type)}`);
-		// TODO: Document error
-		if (!is_tuple_type(type.target))
+		if (!is_tuple_type_reference(type))
 			throw new Error(`Expected tuple type, got ${this.#checker.typeToString(type)}`);
 		const isReadonly = type.target.readonly;
 		const elements = this.#checker.getTypeArguments(type).map((t) => this.#get_type_doc(t));
@@ -517,6 +514,7 @@ class Parser {
 		if (!(type.flags & ts.TypeFlags.Conditional))
 			throw new Error(`Expected conditional type, got ${this.#checker.typeToString(type)}`);
 		let conditional = /** @type {ts.ConditionalType} */ (type);
+		type.getCallSignatures(); // Note: this is required to get resolved types
 		/** @type {Conditional} */
 		let results = {
 			kind: "conditional",

--- a/packages/svelte-docgen/src/parser/type/instantiable.test.ts
+++ b/packages/svelte-docgen/src/parser/type/instantiable.test.ts
@@ -60,6 +60,9 @@ describe("Instantiable types", () => {
 		if (!conditional || !isTypeRef(conditional?.type)) throw new Error("must be a type");
 		const type = types.get(conditional.type)!;
 		expect(type.kind).toBe("conditional");
+		const falsy = (type as Doc.Conditional).falsy!;
+		if (isTypeRef(falsy)) throw new Error("must be a type");
+		expect(falsy.kind).toBe("literal");
 		const truthy = (type as Doc.Conditional).truthy!;
 		if (isTypeRef(truthy)) throw new Error("must be a type");
 		expect(truthy.kind).toBe("substitution");

--- a/packages/svelte-docgen/src/shared.js
+++ b/packages/svelte-docgen/src/shared.js
@@ -18,7 +18,7 @@ const IS_NODE_LIKE = globalThis.process?.cwd !== undefined;
  * @returns {type is ts.ObjectType}
  */
 export function is_object_type(type) {
-	return (type.flags & ts.TypeFlags.Object || type.flags & ts.TypeFlags.NonPrimitive) !== 0;
+	return !!(type.flags & ts.TypeFlags.Object);
 }
 
 /**
@@ -27,16 +27,16 @@ export function is_object_type(type) {
  * @returns {type is ts.TypeReference}
  */
 export function is_type_reference(type) {
-	return is_object_type(type) && (type.objectFlags & ts.ObjectFlags.Reference) !== 0;
+	return is_object_type(type) && !!(type.objectFlags & ts.ObjectFlags.Reference);
 }
 
 /**
  * @internal
  * @param {ts.Type} type
- * @returns {type is ts.TupleType}
+ * @returns {type is ts.TupleTypeReference}
  */
-export function is_tuple_type(type) {
-	return is_object_type(type) && (type.objectFlags & ts.ObjectFlags.Tuple) !== 0;
+export function is_tuple_type_reference(type) {
+	return is_type_reference(type) && !!(type.target.objectFlags & ts.ObjectFlags.Tuple);
 }
 
 /**
@@ -66,7 +66,6 @@ export function get_type_symbol(type) {
  * @typedef GetTypeParams
  * @prop {T} type
  * @prop {Extractor} extractor
- * @prop {string} [self]
  */
 
 /**


### PR DESCRIPTION
- By considering TypeReference, the issue described in the FIXME comment has been addressed:

  ```ts
  // FIXME: Sometimes the constructible type is not recognized with `ts.Type.isClassOrInterface()` - e.g. `Map` - don't know why.
  ```

- By early branching on major categories like StructuredOrInstantiable, unnecessary evaluations are reduced.