### PR TITLE
chore: Update `pathe` to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"eslint-config-prettier": "^9.1.0",
 		"eslint-plugin-svelte": "^2.46.1",
 		"globals": "^15.14.0",
-		"pathe": "^1.1.2",
+		"pathe": "^2.0.0",
 		"prettier": "^3.4.2",
 		"prettier-plugin-svelte": "^3.3.2",
 		"prettier-plugin-tailwindcss": "^0.6.9",
@@ -59,9 +59,6 @@
 		"overrides": {
 			"vite": "^6.0.5",
 			"@sveltejs/vite-plugin-svelte": "^5.0.0"
-		},
-		"patchedDependencies": {
-			"pathe": "patches/pathe.patch"
 		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,11 +23,6 @@ overrides:
   vite: ^6.0.5
   '@sveltejs/vite-plugin-svelte': ^5.0.0
 
-patchedDependencies:
-  pathe:
-    hash: kbjqganfdnztbz7ujevxrce2we
-    path: patches/pathe.patch
-
 importers:
 
   .:
@@ -66,8 +61,8 @@ importers:
         specifier: ^15.14.0
         version: 15.14.0
       pathe:
-        specifier: ^1.1.2
-        version: 1.1.2(patch_hash=kbjqganfdnztbz7ujevxrce2we)
+        specifier: ^2.0.0
+        version: 2.0.0
       prettier:
         specifier: ^3.4.2
         version: 3.4.2
@@ -2980,6 +2975,9 @@ packages:
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
 
+  pathe@2.0.0:
+    resolution: {integrity: sha512-G7n4uhtk9qJt2hlD+UFfsIGY854wpF+zs2bUbQ3CQEUTcn7v25LRsrmurOxTo4bJgjE4qkyshd9ldsEuY9M6xg==}
+
   pathval@2.0.0:
     resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
     engines: {node: '>= 14.16'}
@@ -5275,13 +5273,13 @@ snapshots:
   '@vitest/runner@2.1.8':
     dependencies:
       '@vitest/utils': 2.1.8
-      pathe: 1.1.2(patch_hash=kbjqganfdnztbz7ujevxrce2we)
+      pathe: 1.1.2
 
   '@vitest/snapshot@2.1.8':
     dependencies:
       '@vitest/pretty-format': 2.1.8
       magic-string: 0.30.17
-      pathe: 1.1.2(patch_hash=kbjqganfdnztbz7ujevxrce2we)
+      pathe: 1.1.2
 
   '@vitest/spy@2.1.8':
     dependencies:
@@ -5292,7 +5290,7 @@ snapshots:
       '@vitest/utils': 2.1.8
       fflate: 0.8.2
       flatted: 3.3.2
-      pathe: 1.1.2(patch_hash=kbjqganfdnztbz7ujevxrce2we)
+      pathe: 1.1.2
       sirv: 3.0.0
       tinyglobby: 0.2.10
       tinyrainbow: 1.2.0
@@ -6701,7 +6699,9 @@ snapshots:
 
   path-type@4.0.0: {}
 
-  pathe@1.1.2(patch_hash=kbjqganfdnztbz7ujevxrce2we): {}
+  pathe@1.1.2: {}
+
+  pathe@2.0.0: {}
 
   pathval@2.0.0: {}
 
@@ -7433,7 +7433,7 @@ snapshots:
     dependencies:
       defu: 6.1.4
       ohash: 1.1.4
-      pathe: 1.1.2(patch_hash=kbjqganfdnztbz7ujevxrce2we)
+      pathe: 1.1.2
       ufo: 1.5.4
 
   unist-util-is@6.0.0:
@@ -7513,7 +7513,7 @@ snapshots:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
-      pathe: 1.1.2(patch_hash=kbjqganfdnztbz7ujevxrce2we)
+      pathe: 1.1.2
       vite: 6.0.7(@types/node@22.10.5)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
@@ -7572,7 +7572,7 @@ snapshots:
       debug: 4.4.0
       expect-type: 1.1.0
       magic-string: 0.30.17
-      pathe: 1.1.2(patch_hash=kbjqganfdnztbz7ujevxrce2we)
+      pathe: 1.1.2
       std-env: 3.8.0
       tinybench: 2.9.0
       tinyexec: 0.3.2


### PR DESCRIPTION
https://github.com/unjs/pathe/releases/tag/v2.0.0
https://github.com/unjs/pathe/pull/193 🎉 

Relates: https://github.com/svelte-docgen/svelte-docgen/pull/45